### PR TITLE
【Profile】Avatarを変更するAPIを実装する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 .DS_Store
 /database/data
+/backend/tmp

--- a/backend/.openapi-generator/FILES
+++ b/backend/.openapi-generator/FILES
@@ -1,3 +1,4 @@
+internal/schema/model_avatar.go
 internal/schema/model_error.go
 internal/schema/model_get_access_history_200_response_inner.go
 internal/schema/model_get_access_history_200_response_inner_entering.go
@@ -9,6 +10,5 @@ internal/schema/model_get_user_by_id_200_response_avatar_list_inner.go
 internal/schema/model_post_sign_in_200_response.go
 internal/schema/model_post_sign_in_request.go
 internal/schema/model_post_user_information_request.go
-internal/schema/model_put_avatar_request.go
 internal/schema/model_put_change_password_request.go
 internal/schema/model_status.go

--- a/backend/internal/controllers/avatar_controller.go
+++ b/backend/internal/controllers/avatar_controller.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/services"
+	"github.com/gin-gonic/gin"
+)
+
+func PutAvatarControlller(ctx *gin.Context) {
+	var avatarRequest schema.PutAvatarRequest
+	if err := ctx.BindJSON(&avatarRequest); err != nil {
+		log.Printf("Internal Server Error: failed to bind a request body with a struct: %v\n", err)
+		ctx.JSON(http.StatusBadRequest, schema.Error{
+			Code:    http.StatusBadRequest,
+			Message: err.Error(),
+		})
+	}
+
+	err := services.PutAvatarService(avatarRequest)
+	if err != nil {
+		log.Println(fmt.Errorf("failed to put avatar:%w", err))
+		ctx.JSON(http.StatusInternalServerError, schema.Error{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		})
+	} else {
+		ctx.String(http.StatusOK, "success")
+	}
+}

--- a/backend/internal/controllers/avatar_controller.go
+++ b/backend/internal/controllers/avatar_controller.go
@@ -10,8 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func PutAvatarControlller(ctx *gin.Context) {
-	var avatarRequest schema.PutAvatarRequest
+func PutAvatarController(ctx *gin.Context) {
+	var avatarRequest schema.Avatar
 	if err := ctx.BindJSON(&avatarRequest); err != nil {
 		log.Printf("Internal Server Error: failed to bind a request body with a struct: %v\n", err)
 		ctx.JSON(http.StatusBadRequest, schema.Error{
@@ -20,7 +20,7 @@ func PutAvatarControlller(ctx *gin.Context) {
 		})
 	}
 
-	err := services.PutAvatarService(avatarRequest)
+	avatarResponse, err := services.PutAvatarService(avatarRequest)
 	if err != nil {
 		log.Println(fmt.Errorf("failed to put avatar:%w", err))
 		ctx.JSON(http.StatusInternalServerError, schema.Error{
@@ -28,6 +28,6 @@ func PutAvatarControlller(ctx *gin.Context) {
 			Message: err.Error(),
 		})
 	} else {
-		ctx.String(http.StatusOK, "success")
+		ctx.JSON(http.StatusOK, avatarResponse)
 	}
 }

--- a/backend/internal/controllers/users_controller.go
+++ b/backend/internal/controllers/users_controller.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GetUsersByIdControlller(ctx *gin.Context) {
+func GetUsersByIdController(ctx *gin.Context) {
 	userIdStr := ctx.Param("user_id")
 	userId, err := strconv.Atoi(userIdStr)
 	if err != nil {

--- a/backend/internal/repositories/avatar_repository.go
+++ b/backend/internal/repositories/avatar_repository.go
@@ -7,12 +7,17 @@ import (
 	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
 )
 
-func PutAvatarRepository(avatarRequest schema.PutAvatarRequest) (err error) {
+func PutAvatarRepository(avatarRequest schema.Avatar) (avatarResponse schema.Avatar, err error) {
 	putAvatarQuery := `UPDATE user SET avatar_id = ? WHERE id = ?;`
 	_, err = infrastructures.DB.Exec(putAvatarQuery, avatarRequest.AvatarId, avatarRequest.UserId)
 	if err != nil {
-		return fmt.Errorf("failed to execute query to put avatar: %v", err)
+		return schema.Avatar{}, fmt.Errorf("failed to execute query to put avatar: %v", err)
 	}
 
-	return nil
+	getAvatarIdQuery := `SELECT id, avatar_id FROM user WHERE id = ?;`
+	if err := infrastructures.DB.QueryRow(getAvatarIdQuery, avatarRequest.UserId).Scan(&avatarResponse.UserId, &avatarResponse.AvatarId); err != nil {
+		return schema.Avatar{}, fmt.Errorf("failed to execute a query to get avatar_id: %v", err)
+	}
+
+	return avatarResponse, nil
 }

--- a/backend/internal/repositories/avatar_repository.go
+++ b/backend/internal/repositories/avatar_repository.go
@@ -1,0 +1,18 @@
+package repositories
+
+import (
+	"fmt"
+
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/infrastructures"
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
+)
+
+func PutAvatarRepository(avatarRequest schema.PutAvatarRequest) (err error) {
+	putAvatarQuery := `UPDATE user SET avatar_id = ? WHERE id = ?;`
+	_, err = infrastructures.DB.Exec(putAvatarQuery, avatarRequest.AvatarId, avatarRequest.UserId)
+	if err != nil {
+		return fmt.Errorf("failed to execute query to put avatar: %v", err)
+	}
+
+	return nil
+}

--- a/backend/internal/routers.go
+++ b/backend/internal/routers.go
@@ -19,8 +19,8 @@ func SetRoutes(router *gin.Engine) {
 
 	v1 := router.Group("/v1")
 	{
-		v1.GET("/users/:user_id", controllers.GetUsersByIdControlller)
-		v1.PUT("/avatar", controllers.PutAvatarControlller)
+		v1.GET("/users/:user_id", controllers.GetUsersByIdController)
+		v1.PUT("/avatar", controllers.PutAvatarController)
 		v1.PUT("/status", controllers.PutStatusController)
 	}
 }

--- a/backend/internal/routers.go
+++ b/backend/internal/routers.go
@@ -20,5 +20,6 @@ func SetRoutes(router *gin.Engine) {
 	v1 := router.Group("/v1")
 	{
 		v1.GET("/users/:user_id", controllers.GetUsersByIdControlller)
+		v1.PUT("/avatar", controllers.PutAvatarControlller)
 	}
 }

--- a/backend/internal/schema/model_avatar.go
+++ b/backend/internal/schema/model_avatar.go
@@ -9,7 +9,7 @@
 
 package schema
 
-type PutAvatarRequest struct {
+type Avatar struct {
 
 	UserId int32 `json:"user_id"`
 

--- a/backend/internal/services/avatar_service.go
+++ b/backend/internal/services/avatar_service.go
@@ -5,11 +5,11 @@ import (
 	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
 )
 
-func PutAvatarService(avatarRequest schema.PutAvatarRequest) (err error) {
-	err = repositories.PutAvatarRepository(avatarRequest)
+func PutAvatarService(avatarRequest schema.Avatar) (avatarResponse schema.Avatar, err error) {
+	avatarResponse, err = repositories.PutAvatarRepository(avatarRequest)
 	if err != nil {
-		return err
+		return schema.Avatar{}, err
 	}
 
-	return nil
+	return avatarResponse, nil
 }

--- a/backend/internal/services/avatar_service.go
+++ b/backend/internal/services/avatar_service.go
@@ -1,0 +1,15 @@
+package services
+
+import (
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/repositories"
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
+)
+
+func PutAvatarService(avatarRequest schema.PutAvatarRequest) (err error) {
+	err = repositories.PutAvatarRepository(avatarRequest)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/tmp/air.log
+++ b/backend/tmp/air.log
@@ -1,1 +1,0 @@
-exit status 1exit status 1exit status 1

--- a/frontend/src/schema/api.ts
+++ b/frontend/src/schema/api.ts
@@ -26,6 +26,25 @@ import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerM
 /**
  * 
  * @export
+ * @interface Avatar
+ */
+export interface Avatar {
+    /**
+     * 
+     * @type {number}
+     * @memberof Avatar
+     */
+    'user_id': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof Avatar
+     */
+    'avatar_id': number;
+}
+/**
+ * 
+ * @export
  * @interface GetAccessHistory200ResponseInner
  */
 export interface GetAccessHistory200ResponseInner {
@@ -435,25 +454,6 @@ export interface PostUserInformationRequest {
      * @memberof PostUserInformationRequest
      */
     'password': string;
-}
-/**
- * 
- * @export
- * @interface PutAvatarRequest
- */
-export interface PutAvatarRequest {
-    /**
-     * 
-     * @type {number}
-     * @memberof PutAvatarRequest
-     */
-    'user_id': number;
-    /**
-     * 
-     * @type {number}
-     * @memberof PutAvatarRequest
-     */
-    'avatar_id': number;
 }
 /**
  * 
@@ -1345,11 +1345,13 @@ export const PutAvatarApiAxiosParamCreator = function (configuration?: Configura
         /**
          * 
          * @summary update avatar
-         * @param {PutAvatarRequest} [putAvatarRequest] 
+         * @param {Avatar} avatar request body of update avatar
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        putAvatar: async (putAvatarRequest?: PutAvatarRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        putAvatar: async (avatar: Avatar, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'avatar' is not null or undefined
+            assertParamExists('putAvatar', 'avatar', avatar)
             const localVarPath = `/avatar`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -1369,7 +1371,7 @@ export const PutAvatarApiAxiosParamCreator = function (configuration?: Configura
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(putAvatarRequest, localVarRequestOptions, configuration)
+            localVarRequestOptions.data = serializeDataIfNeeded(avatar, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1389,12 +1391,12 @@ export const PutAvatarApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary update avatar
-         * @param {PutAvatarRequest} [putAvatarRequest] 
+         * @param {Avatar} avatar request body of update avatar
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async putAvatar(putAvatarRequest?: PutAvatarRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.putAvatar(putAvatarRequest, options);
+        async putAvatar(avatar: Avatar, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Avatar>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.putAvatar(avatar, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['PutAvatarApi.putAvatar']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -1412,12 +1414,12 @@ export const PutAvatarApiFactory = function (configuration?: Configuration, base
         /**
          * 
          * @summary update avatar
-         * @param {PutAvatarRequest} [putAvatarRequest] 
+         * @param {Avatar} avatar request body of update avatar
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        putAvatar(putAvatarRequest?: PutAvatarRequest, options?: any): AxiosPromise<void> {
-            return localVarFp.putAvatar(putAvatarRequest, options).then((request) => request(axios, basePath));
+        putAvatar(avatar: Avatar, options?: any): AxiosPromise<Avatar> {
+            return localVarFp.putAvatar(avatar, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -1432,13 +1434,13 @@ export class PutAvatarApi extends BaseAPI {
     /**
      * 
      * @summary update avatar
-     * @param {PutAvatarRequest} [putAvatarRequest] 
+     * @param {Avatar} avatar request body of update avatar
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof PutAvatarApi
      */
-    public putAvatar(putAvatarRequest?: PutAvatarRequest, options?: RawAxiosRequestConfig) {
-        return PutAvatarApiFp(this.configuration).putAvatar(putAvatarRequest, options).then((request) => request(this.axios, this.basePath));
+    public putAvatar(avatar: Avatar, options?: RawAxiosRequestConfig) {
+        return PutAvatarApiFp(this.configuration).putAvatar(avatar, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -94,10 +94,17 @@ paths:
       requestBody:
         description: request body of update avatar
         required: true
-        $ref: '#/components/requestBodies/Avatar'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Avatar'
       responses:
-        '204':
+        '200':
           description: successful to update avatar
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Avatar'
         default:
           description: unexpected error
           content:
@@ -215,21 +222,6 @@ paths:
                 $ref: "#/components/schemas/Error"
 components:
   requestBodies:
-    Avatar:
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              user_id:
-                type: integer
-                format: uint64
-              avatar_id:
-                type: integer
-                format: uint64
-            required:
-              - user_id
-              - avatar_id
     SignInUser:
       content:
         application/json:
@@ -530,6 +522,18 @@ components:
       required:
         - user_id
         - status
+    Avatar:
+      type: object
+      properties:
+        user_id:
+          type: integer
+          format: uint64
+        avatar_id:
+          type: integer
+          format: uint64
+      required:
+        - user_id
+        - avatar_id
     Error:
       type: object
       properties:


### PR DESCRIPTION
## 背景

<!-- なぜ変更したのか -->

- Avatarを変更するAPIを実装する

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- `PUT /avatar`をスキーマを基に作成する
- 変更内容はDBに反映させること

- [x] 変更したavatar情報がuserテーブルに反映されていること

このAPIはuserテーブルのavatar.idを更新するのみであるため，responseはsuccessの文字列を返している．
更新されたavatar.idをresponseとして返すことも可能．

## 関連 Issue

<!-- #xxで指定 -->

- #22 

## 検証
### avatarIdを2に設定してるユーザ
![image](https://github.com/user-attachments/assets/afe76a0f-8bd8-415f-9d3e-4fb367442144)

### avatarIdを更新
![image](https://github.com/user-attachments/assets/a7825f86-2cae-4101-b2c9-70ab0e352a12)

### 更新後のユーザ情報
![image](https://github.com/user-attachments/assets/d941313e-dba7-471e-a484-861258f1f6d3)


