### PR TITLE
入退室を行った際にplace_idを変更し、historyにも保存する

### DIFF
--- a/backend/internal/infrastructures/db.go
+++ b/backend/internal/infrastructures/db.go
@@ -23,7 +23,7 @@ func openDB() {
 	hostName := os.Getenv("MYSQL_HOSTNAME")
 	dbName := os.Getenv("MYSQL_DATABASE")
 
-	DB, err = sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?", user, password, hostName, dbName))
+	DB, err = sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", user, password, hostName, dbName))
 	if err != nil {
 		log.Fatalf("main sql.Open error err:%v", err)
 	}

--- a/backend/internal/models/status_model.go
+++ b/backend/internal/models/status_model.go
@@ -13,3 +13,7 @@ type Status struct {
 	id             int32
 	status_name           string
 }
+
+const (
+	KC104 = "KC104"
+)

--- a/backend/internal/repositories/status_repository.go
+++ b/backend/internal/repositories/status_repository.go
@@ -3,8 +3,10 @@ package repositories
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/infrastructures"
+	model "github.com/ISDL-dev/ISDL-Sentinel/backend/internal/models"
 )
 
 func GetAllStatusRepository() (statusList *sql.Rows, err error) {
@@ -15,11 +17,106 @@ func GetAllStatusRepository() (statusList *sql.Rows, err error) {
 	return getRows, nil
 }
 
-func PutStatusRepository(userId int32, statusId int32) (err error) {
-	_, err = infrastructures.DB.Query("UPDATE user SET status_id = ? WHERE id = ?;", statusId, userId)
+func GetInRoomPlaceIdRepository() (getStatusId int32, err error){
+	getRows, err := infrastructures.DB.Query("SELECT id FROM place WHERE place_name = ?;", model.KC104)
 	if err != nil {
-		return fmt.Errorf("getRows db.Query error err:%w", err)
-	} else {
-		return nil
+		return 0, fmt.Errorf("getRows GetInRoomStatusId Query error err:%w", err)
 	}
+	for getRows.Next() {
+		err := getRows.Scan(&getStatusId)
+		if err != nil {
+			return 0, fmt.Errorf("failed to find target status id: %v", err)
+		}
+	}
+	return getStatusId, nil
+}
+
+func PutStatusRepository(userId int32, statusId int32, placeId int32) (err error) {
+	var enteringHistoryId int32
+	var enteredAt time.Time
+
+	tx, err := infrastructures.DB.Begin()
+	if err != nil {
+		return fmt.Errorf("fail to begin transaction error err:%w", err)
+	}
+	if placeId == 0 {
+		putOutRoomQuery := `
+		UPDATE user 
+		SET 
+			place_id = ?, 
+			status_id = ?
+		WHERE 
+			id = ?;`
+		_, err = tx.Exec(putOutRoomQuery, sql.NullInt32{}, statusId, userId)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("putInRoomQuery error err:%w", err)
+		}
+		getLatestEnteringHistoryQuery :=`
+		SELECT 
+			id AS enteringHistoryId, 
+			entered_at AS enteredAt 
+		FROM 
+			entering_history 
+		WHERE 
+			user_id = ?
+		ORDER BY 
+			entered_at DESC 
+		LIMIT 
+			1;`
+		getRows, err := infrastructures.DB.Query(getLatestEnteringHistoryQuery, userId)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("getLatestEnteringHistoryQuery error err:%w", err)
+		}
+		for getRows.Next() {
+			err := getRows.Scan(&enteringHistoryId, &enteredAt)
+			if err != nil {
+				tx.Rollback()
+				return fmt.Errorf("failed to find entering history: %v", err)
+			}
+		}
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("putInRoomQuery error err:%w", err)
+		}
+		insertOutRoomQuery := `
+		INSERT INTO leaving_history (user_id, entering_history_id, left_at, stay_time)
+		VALUES (
+			?, 
+			?, 
+			NOW(), 
+			TIMEDIFF(NOW(), ?)
+		);`
+		_, err = tx.Exec(insertOutRoomQuery, userId, enteringHistoryId, enteredAt)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("insertOutRoomQuery error err:%w", err)
+		}
+	} else {
+		putInRoomQuery := `
+		UPDATE user 
+		SET 
+			place_id = ?, 
+			status_id = ?
+		WHERE 
+			id = ?;`
+		_, err = tx.Exec(putInRoomQuery, placeId, statusId, userId)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("putInRoomQuery error err:%w", err)
+		}
+		insertInRoomQuery := `
+		INSERT INTO entering_history (user_id, entered_at)
+		VALUES (?, NOW());`
+		_, err = tx.Exec(insertInRoomQuery, userId)
+		if err != nil {
+			tx.Rollback()
+			return fmt.Errorf("insertInRoomQuery error err:%w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("fail to commit transaction error err:%w", err)
+	}
+	return nil
 }

--- a/backend/internal/services/status_service.go
+++ b/backend/internal/services/status_service.go
@@ -33,14 +33,31 @@ func SelectApplyStatusId(status string) (id int32, statusName string, err error)
 	return 0, targetStatusName, nil
 }
 
+func SelectApplyPlaceId(targetStatusName string) (applyPlaceId int32, err error){
+	if targetStatusName == model.IN_ROOM {
+		applyPlaceId, err = repositories.GetInRoomPlaceIdRepository() 
+		if err != nil {
+			return 0, fmt.Errorf("failed to execute query to get in room place id: %v", err)
+		}
+	} else {
+		applyPlaceId = 0
+	}
+	return applyPlaceId, nil
+}
+
 func PutStatusService(status schema.Status) (user schema.Status, err error) {
 	var applyStatusId int32
+	var applyPlaceId int32
 	var targetStatusName string
 	applyStatusId, targetStatusName, err = SelectApplyStatusId(status.Status)
 	if err != nil {
 		return schema.Status{}, fmt.Errorf("failed to find target status id: %v", err)
 	}
-	err = repositories.PutStatusRepository(status.UserId, applyStatusId)
+	applyPlaceId, err = SelectApplyPlaceId(targetStatusName)
+	if err != nil {
+		return schema.Status{}, fmt.Errorf("failed to find target place id: %v", err)
+	}
+	err = repositories.PutStatusRepository(status.UserId, applyStatusId, applyPlaceId)
 	if err != nil {
 		return schema.Status{}, fmt.Errorf("failed to change user status: %v", err)
 	}


### PR DESCRIPTION
## 背景

<!-- なぜ変更したのか -->

- 現状、入退室をした際ステータスを変えるだけでは、退室しているのに場所は'KC104'などになってしまうのでその対応を前のIssueから分割した

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- 入退室処理と同時に場所の情報も更新する
- 入室した際にentering_historyに現在時刻を追加
- 退室した際はそのuser_idに該当するentering_historyのレコードから一番直近の時刻を取得し差分を算出
- 算出した差分を滞在時間として現在時刻とともにentering_historyに追加

## 関連 Issue

<!-- #xxで指定 -->

- #37 
- #38 
（DBのトランザクションとか分けるとやりづらかったので、2つ一気にPR作りました）

## 画面イメージ
- 入室ボタンを押した時に入室者一覧に表示され、場所がKC104になっている
<img width="1097" alt="スクリーンショット 2024-07-21 15 46 58" src="https://github.com/user-attachments/assets/05e6567a-6e64-485e-9f85-c17a87aff8de">

- 退室ボタンを押した際に履歴テーブルに退室時間と滞在時間が記録されている

![スクリーンショット 2024-07-21 16 20 16](https://github.com/user-attachments/assets/2a17937e-4736-4676-976e-5f06f1de6672)

<!-- frontendの実装があるときのみ -->
