### PR TITLE
【Access history】今月の入室および退室履歴を取得するAPIを実装する

### DIFF
--- a/backend/internal/controllers/access-history_controller.go
+++ b/backend/internal/controllers/access-history_controller.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/services"
+	"github.com/gin-gonic/gin"
+)
+
+func GetAccessHistoryController(ctx *gin.Context) {
+	var accessHistrory []schema.GetAccessHistory200ResponseInner
+	date := ctx.Param("date")
+
+	accessHistrory, err := services.GetAccessHistoryService(date)
+	if err != nil {
+		log.Println(err.Error())
+		ctx.JSON(http.StatusInternalServerError, schema.Error{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		})
+	} else {
+		ctx.JSON(http.StatusOK, accessHistrory)
+	}
+}

--- a/backend/internal/repositories/access_history_repository.go
+++ b/backend/internal/repositories/access_history_repository.go
@@ -1,0 +1,101 @@
+package repositories
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/infrastructures"
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
+)
+
+func GetAccessHistoryRepository(date string) (accessHistory []schema.GetAccessHistory200ResponseInner, err error) {
+	var accessHistoryInner schema.GetAccessHistory200ResponseInner
+	var firstEntering schema.GetAccessHistory200ResponseInnerEntering
+	var firstEnteringList []schema.GetAccessHistory200ResponseInnerEntering
+	var lastLeaving schema.GetAccessHistory200ResponseInnerLeaving
+	var lastLeavingList []schema.GetAccessHistory200ResponseInnerLeaving
+
+	getFirstEnteringHistoryQuery := `
+		SELECT 
+			eh.user_id,
+			u.name AS user_name,
+			u.avatar_id,
+			a.img_path AS avatar_img_path,
+			eh.entered_at
+		FROM 
+			entering_history eh
+		JOIN 
+			user u ON eh.user_id = u.id
+		JOIN 
+			avatar a ON u.avatar_id = a.id
+		WHERE 
+			eh.is_first_entering = true
+			AND DATE_FORMAT(eh.entered_at, '%Y-%m') = ?;`
+	getFirstEnteringRows, err := infrastructures.DB.Query(getFirstEnteringHistoryQuery, date)
+	if err != nil {
+		return []schema.GetAccessHistory200ResponseInner{}, fmt.Errorf("failed to execute query to get first entering history:%w", err)
+	}
+	for getFirstEnteringRows.Next() {
+		err := getFirstEnteringRows.Scan(
+			&firstEntering.UserId,
+			&firstEntering.UserName,
+			&firstEntering.AvatarId,
+			&firstEntering.AvatarImgPath,
+			&firstEntering.EnteredAt)
+		if err != nil {
+			return []schema.GetAccessHistory200ResponseInner{}, fmt.Errorf("failed to execute query to get first entering history: %v", err)
+		}
+		firstEnteringList = append(firstEnteringList, firstEntering)
+	}
+
+	getLastLeavingHistoryQuery := `
+		SELECT 
+			lh.user_id,
+			u.name AS user_name,
+			u.avatar_id,
+			a.img_path AS avatar_img_path,
+			lh.left_at
+		FROM 
+			leaving_history lh
+		JOIN 
+			user u ON lh.user_id = u.id
+		JOIN 
+			avatar a ON u.avatar_id = a.id
+		WHERE 
+			lh.is_last_leaving = true
+			AND DATE_FORMAT(lh.left_at, '%Y-%m') = ?;`
+	getLastLeavingRows, err := infrastructures.DB.Query(getLastLeavingHistoryQuery, date)
+	if err != nil {
+		return []schema.GetAccessHistory200ResponseInner{}, fmt.Errorf("failed to execute query to get last leaving history:%w", err)
+	}
+	for getLastLeavingRows.Next() {
+		err := getLastLeavingRows.Scan(
+			&lastLeaving.UserId,
+			&lastLeaving.UserName,
+			&lastLeaving.AvatarId,
+			&lastLeaving.AvatarImgPath,
+			&lastLeaving.LeftAt)
+		if err != nil {
+			return []schema.GetAccessHistory200ResponseInner{}, fmt.Errorf("failed to execute query to get last leaving history: %v", err)
+		}
+		lastLeavingList = append(lastLeavingList, lastLeaving)
+	}
+
+	for i := 0; i < len(firstEnteringList); i++ {
+		dateParts := strings.Split(firstEnteringList[i].EnteredAt, "T")
+		if len(dateParts) > 0 {
+			accessHistoryInner.Date = dateParts[0]
+		} else {
+			accessHistoryInner.Date = ""
+		}
+		accessHistoryInner.Entering = firstEnteringList[i]
+		if i < len(lastLeavingList) {
+			accessHistoryInner.Leaving = lastLeavingList[i]
+		} else {
+			accessHistoryInner.Leaving = schema.GetAccessHistory200ResponseInnerLeaving{}
+		}
+		accessHistory = append(accessHistory, accessHistoryInner)
+	}
+
+	return accessHistory, nil
+}

--- a/backend/internal/routers.go
+++ b/backend/internal/routers.go
@@ -23,5 +23,6 @@ func SetRoutes(router *gin.Engine) {
 		v1.PUT("/avatar", controllers.PutAvatarController)
 		v1.GET("/attendees-list", controllers.GetAttendeesListController)
 		v1.PUT("/status", controllers.PutStatusController)
+		v1.GET("/access-history/:date", controllers.GetAccessHistoryController)
 	}
 }

--- a/backend/internal/services/access_history_service.go
+++ b/backend/internal/services/access_history_service.go
@@ -1,0 +1,17 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/repositories"
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
+)
+
+func GetAccessHistoryService(date string) (accessHistrory []schema.GetAccessHistory200ResponseInner, err error) {
+	accessHistrory, err = repositories.GetAccessHistoryRepository(date)
+	if err != nil {
+		return []schema.GetAccessHistory200ResponseInner{}, fmt.Errorf("failed to execute query to get access history: %v", err)
+	}
+
+	return accessHistrory, nil
+}

--- a/database/sqls/init_tables.sql
+++ b/database/sqls/init_tables.sql
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS entering_history(
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     user_id INT UNSIGNED NOT NULL,
     entered_at DATETIME NOT NULL,
+    is_first_entering Boolean NOT NULL,
     FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE RESTRICT ON UPDATE CASCADE
 ) DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
@@ -56,6 +57,7 @@ CREATE TABLE IF NOT EXISTS leaving_history(
     entering_history_id INT UNSIGNED NOT NULL,
     left_at DATETIME NOT NULL,
     stay_time TIME NOT NULL,
+    is_last_leaving Boolean NOT NULL,
     FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE RESTRICT ON UPDATE CASCADE,
     FOREIGN KEY (entering_history_id) REFERENCES entering_history(id) ON DELETE CASCADE ON UPDATE CASCADE
 ) DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
@@ -138,21 +140,33 @@ INSERT INTO user (name, mail_address, password, number_of_coin, status_id, place
 ('吉田 玲音', 'yoshida.reon@mikilab.doshisha.ac.jp', 'project443', 959, 3, 1, 5, 1);
 
 
-INSERT INTO entering_history (user_id, entered_at) VALUES 
-(9, '2024-07-16 09:00:00'),
-(9, '2024-07-17 09:00:00'),
-(10, '2024-07-16 09:00:00'),
-(10, '2024-07-17 09:00:00'),
-(14, '2024-07-16 09:00:00'),
-(14, '2024-07-17 09:00:00');
+INSERT INTO entering_history (user_id, entered_at, is_first_entering) VALUES 
+(2, '2024-07-01 09:00:00', true),
+(10, '2024-07-01 09:30:00', false),
+(9, '2024-07-01 10:00:00', false),
+(9, '2024-07-16 09:30:00', true),
+(10, '2024-07-16 10:00:00', false),
+(14, '2024-07-16 11:00:00', false),
+(15, '2024-07-16 13:00:00', true),
+(16, '2024-07-16 14:00:00', false),
+(17, '2024-07-16 15:00:00', false),
+(9, '2024-07-31 09:00:00', true),
+(10, '2024-07-31 10:00:00', false),
+(14, '2024-07-31 11:00:00', false);
 
-INSERT INTO leaving_history (user_id, entering_history_id, left_at, stay_time) VALUES 
-(9, 1, '2024-07-16 18:00:00', '09:00:00'),
-(9, 2, '2024-07-17 18:00:00', '09:00:00'),
-(10, 3, '2024-07-16 18:00:00', '09:00:00'),
-(10, 4, '2024-07-17 18:00:00', '09:00:00'),
-(14, 5, '2024-07-16 18:00:00', '09:00:00'),
-(14, 6, '2024-07-17 18:00:00', '09:00:00');
+INSERT INTO leaving_history (user_id, entering_history_id, left_at, stay_time, is_last_leaving) VALUES 
+(2, 1, '2024-07-01 18:00:00', '09:00:00', false),
+(10, 2, '2024-07-01 18:30:00', '09:00:00', false),
+(9, 3, '2024-07-01 18:40:00', '08:40:00', true),
+(9, 4, '2024-07-16 12:00:00', '02:30:00', false),
+(10, 5, '2024-07-16 12:30:00', '02:30:00', false),
+(14, 6, '2024-07-16 12:40:00', '01:40:00', true),
+(15, 7, '2024-07-16 18:00:00', '05:00:00', false),
+(16, 8, '2024-07-16 19:00:00', '05:00:00', false),
+(17, 9, '2024-07-16 20:00:00', '05:00:00', true),
+(10, 11, '2024-07-31 18:00:00', '08:00:00', false),
+(9, 10, '2024-07-31 18:30:00', '09:30:00', false),
+(14, 12, '2024-07-31 20:00:00', '09:00:00', true);
 
 INSERT INTO lab_asistant_shift (user_id, shift_day) VALUES 
 (9, '2024-07-16'),

--- a/frontend/src/schema/api.ts
+++ b/frontend/src/schema/api.ts
@@ -501,19 +501,23 @@ export interface Status {
 }
 
 /**
- * GetAccessHistoryApi - axios parameter creator
+ * AccessHistoryApi - axios parameter creator
  * @export
  */
-export const GetAccessHistoryApiAxiosParamCreator = function (configuration?: Configuration) {
+export const AccessHistoryApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
          * 
          * @summary Get access history
+         * @param {string} date 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAccessHistory: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/access-history`;
+        getAccessHistory: async (date: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'date' is not null or undefined
+            assertParamExists('getAccessHistory', 'date', date)
+            const localVarPath = `/access-history/{date}`
+                .replace(`{${"date"}}`, encodeURIComponent(String(date)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -540,72 +544,75 @@ export const GetAccessHistoryApiAxiosParamCreator = function (configuration?: Co
 };
 
 /**
- * GetAccessHistoryApi - functional programming interface
+ * AccessHistoryApi - functional programming interface
  * @export
  */
-export const GetAccessHistoryApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = GetAccessHistoryApiAxiosParamCreator(configuration)
+export const AccessHistoryApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = AccessHistoryApiAxiosParamCreator(configuration)
     return {
         /**
          * 
          * @summary Get access history
+         * @param {string} date 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getAccessHistory(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetAccessHistory200ResponseInner>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAccessHistory(options);
+        async getAccessHistory(date: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetAccessHistory200ResponseInner>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAccessHistory(date, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['GetAccessHistoryApi.getAccessHistory']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['AccessHistoryApi.getAccessHistory']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
     }
 };
 
 /**
- * GetAccessHistoryApi - factory interface
+ * AccessHistoryApi - factory interface
  * @export
  */
-export const GetAccessHistoryApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = GetAccessHistoryApiFp(configuration)
+export const AccessHistoryApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = AccessHistoryApiFp(configuration)
     return {
         /**
          * 
          * @summary Get access history
+         * @param {string} date 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAccessHistory(options?: any): AxiosPromise<Array<GetAccessHistory200ResponseInner>> {
-            return localVarFp.getAccessHistory(options).then((request) => request(axios, basePath));
+        getAccessHistory(date: string, options?: any): AxiosPromise<Array<GetAccessHistory200ResponseInner>> {
+            return localVarFp.getAccessHistory(date, options).then((request) => request(axios, basePath));
         },
     };
 };
 
 /**
- * GetAccessHistoryApi - object-oriented interface
+ * AccessHistoryApi - object-oriented interface
  * @export
- * @class GetAccessHistoryApi
+ * @class AccessHistoryApi
  * @extends {BaseAPI}
  */
-export class GetAccessHistoryApi extends BaseAPI {
+export class AccessHistoryApi extends BaseAPI {
     /**
      * 
      * @summary Get access history
+     * @param {string} date 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
-     * @memberof GetAccessHistoryApi
+     * @memberof AccessHistoryApi
      */
-    public getAccessHistory(options?: RawAxiosRequestConfig) {
-        return GetAccessHistoryApiFp(this.configuration).getAccessHistory(options).then((request) => request(this.axios, this.basePath));
+    public getAccessHistory(date: string, options?: RawAxiosRequestConfig) {
+        return AccessHistoryApiFp(this.configuration).getAccessHistory(date, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
 
 
 /**
- * GetAttendeesListApi - axios parameter creator
+ * AttendeesListApi - axios parameter creator
  * @export
  */
-export const GetAttendeesListApiAxiosParamCreator = function (configuration?: Configuration) {
+export const AttendeesListApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
          * 
@@ -637,929 +644,6 @@ export const GetAttendeesListApiAxiosParamCreator = function (configuration?: Co
                 options: localVarRequestOptions,
             };
         },
-    }
-};
-
-/**
- * GetAttendeesListApi - functional programming interface
- * @export
- */
-export const GetAttendeesListApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = GetAttendeesListApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary Get attendees list
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getAttendeesList(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetAttendeesList200ResponseInner>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAttendeesList(options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['GetAttendeesListApi.getAttendeesList']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * GetAttendeesListApi - factory interface
- * @export
- */
-export const GetAttendeesListApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = GetAttendeesListApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary Get attendees list
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAttendeesList(options?: any): AxiosPromise<Array<GetAttendeesList200ResponseInner>> {
-            return localVarFp.getAttendeesList(options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * GetAttendeesListApi - object-oriented interface
- * @export
- * @class GetAttendeesListApi
- * @extends {BaseAPI}
- */
-export class GetAttendeesListApi extends BaseAPI {
-    /**
-     * 
-     * @summary Get attendees list
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof GetAttendeesListApi
-     */
-    public getAttendeesList(options?: RawAxiosRequestConfig) {
-        return GetAttendeesListApiFp(this.configuration).getAttendeesList(options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * GetAvatarByIdApi - axios parameter creator
- * @export
- */
-export const GetAvatarByIdApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * 
-         * @summary Get an avatar by ID
-         * @param {number} count 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAvatarById: async (count: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'count' is not null or undefined
-            assertParamExists('getAvatarById', 'count', count)
-            const localVarPath = `/avatar/{count}`
-                .replace(`{${"count"}}`, encodeURIComponent(String(count)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * GetAvatarByIdApi - functional programming interface
- * @export
- */
-export const GetAvatarByIdApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = GetAvatarByIdApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary Get an avatar by ID
-         * @param {number} count 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getAvatarById(count: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetUserById200ResponseAvatarListInner>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAvatarById(count, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['GetAvatarByIdApi.getAvatarById']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * GetAvatarByIdApi - factory interface
- * @export
- */
-export const GetAvatarByIdApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = GetAvatarByIdApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary Get an avatar by ID
-         * @param {number} count 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAvatarById(count: number, options?: any): AxiosPromise<Array<GetUserById200ResponseAvatarListInner>> {
-            return localVarFp.getAvatarById(count, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * GetAvatarByIdApi - object-oriented interface
- * @export
- * @class GetAvatarByIdApi
- * @extends {BaseAPI}
- */
-export class GetAvatarByIdApi extends BaseAPI {
-    /**
-     * 
-     * @summary Get an avatar by ID
-     * @param {number} count 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof GetAvatarByIdApi
-     */
-    public getAvatarById(count: number, options?: RawAxiosRequestConfig) {
-        return GetAvatarByIdApiFp(this.configuration).getAvatarById(count, options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * GetAvatarListApi - axios parameter creator
- * @export
- */
-export const GetAvatarListApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * 
-         * @summary Get avatar list
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAvatarList: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/avatar-list`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * GetAvatarListApi - functional programming interface
- * @export
- */
-export const GetAvatarListApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = GetAvatarListApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary Get avatar list
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getAvatarList(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetUserById200ResponseAvatarListInner>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAvatarList(options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['GetAvatarListApi.getAvatarList']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * GetAvatarListApi - factory interface
- * @export
- */
-export const GetAvatarListApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = GetAvatarListApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary Get avatar list
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAvatarList(options?: any): AxiosPromise<Array<GetUserById200ResponseAvatarListInner>> {
-            return localVarFp.getAvatarList(options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * GetAvatarListApi - object-oriented interface
- * @export
- * @class GetAvatarListApi
- * @extends {BaseAPI}
- */
-export class GetAvatarListApi extends BaseAPI {
-    /**
-     * 
-     * @summary Get avatar list
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof GetAvatarListApi
-     */
-    public getAvatarList(options?: RawAxiosRequestConfig) {
-        return GetAvatarListApiFp(this.configuration).getAvatarList(options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * GetRankingApi - axios parameter creator
- * @export
- */
-export const GetRankingApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * 
-         * @summary Get ranking
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getRanking: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/ranking`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * GetRankingApi - functional programming interface
- * @export
- */
-export const GetRankingApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = GetRankingApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary Get ranking
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getRanking(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetRanking200ResponseInner>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getRanking(options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['GetRankingApi.getRanking']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * GetRankingApi - factory interface
- * @export
- */
-export const GetRankingApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = GetRankingApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary Get ranking
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getRanking(options?: any): AxiosPromise<Array<GetRanking200ResponseInner>> {
-            return localVarFp.getRanking(options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * GetRankingApi - object-oriented interface
- * @export
- * @class GetRankingApi
- * @extends {BaseAPI}
- */
-export class GetRankingApi extends BaseAPI {
-    /**
-     * 
-     * @summary Get ranking
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof GetRankingApi
-     */
-    public getRanking(options?: RawAxiosRequestConfig) {
-        return GetRankingApiFp(this.configuration).getRanking(options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * GetUserByIdApi - axios parameter creator
- * @export
- */
-export const GetUserByIdApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * 
-         * @summary Get a user by ID
-         * @param {number} userId 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getUserById: async (userId: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'userId' is not null or undefined
-            assertParamExists('getUserById', 'userId', userId)
-            const localVarPath = `/users/{user_id}`
-                .replace(`{${"user_id"}}`, encodeURIComponent(String(userId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * GetUserByIdApi - functional programming interface
- * @export
- */
-export const GetUserByIdApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = GetUserByIdApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary Get a user by ID
-         * @param {number} userId 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getUserById(userId: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetUserById200Response>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserById(userId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['GetUserByIdApi.getUserById']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * GetUserByIdApi - factory interface
- * @export
- */
-export const GetUserByIdApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = GetUserByIdApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary Get a user by ID
-         * @param {number} userId 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getUserById(userId: number, options?: any): AxiosPromise<GetUserById200Response> {
-            return localVarFp.getUserById(userId, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * GetUserByIdApi - object-oriented interface
- * @export
- * @class GetUserByIdApi
- * @extends {BaseAPI}
- */
-export class GetUserByIdApi extends BaseAPI {
-    /**
-     * 
-     * @summary Get a user by ID
-     * @param {number} userId 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof GetUserByIdApi
-     */
-    public getUserById(userId: number, options?: RawAxiosRequestConfig) {
-        return GetUserByIdApiFp(this.configuration).getUserById(userId, options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * PostSignInApi - axios parameter creator
- * @export
- */
-export const PostSignInApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * 
-         * @summary Sign in
-         * @param {PostSignInRequest} [postSignInRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        postSignIn: async (postSignInRequest?: PostSignInRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/sign-in`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(postSignInRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * PostSignInApi - functional programming interface
- * @export
- */
-export const PostSignInApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = PostSignInApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary Sign in
-         * @param {PostSignInRequest} [postSignInRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async postSignIn(postSignInRequest?: PostSignInRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PostSignIn200Response>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.postSignIn(postSignInRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['PostSignInApi.postSignIn']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * PostSignInApi - factory interface
- * @export
- */
-export const PostSignInApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = PostSignInApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary Sign in
-         * @param {PostSignInRequest} [postSignInRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        postSignIn(postSignInRequest?: PostSignInRequest, options?: any): AxiosPromise<PostSignIn200Response> {
-            return localVarFp.postSignIn(postSignInRequest, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * PostSignInApi - object-oriented interface
- * @export
- * @class PostSignInApi
- * @extends {BaseAPI}
- */
-export class PostSignInApi extends BaseAPI {
-    /**
-     * 
-     * @summary Sign in
-     * @param {PostSignInRequest} [postSignInRequest] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof PostSignInApi
-     */
-    public postSignIn(postSignInRequest?: PostSignInRequest, options?: RawAxiosRequestConfig) {
-        return PostSignInApiFp(this.configuration).postSignIn(postSignInRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * PostUserInformationApi - axios parameter creator
- * @export
- */
-export const PostUserInformationApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * 
-         * @summary Create user information
-         * @param {PostUserInformationRequest} [postUserInformationRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        postUserInformation: async (postUserInformationRequest?: PostUserInformationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/sign-up`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(postUserInformationRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * PostUserInformationApi - functional programming interface
- * @export
- */
-export const PostUserInformationApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = PostUserInformationApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary Create user information
-         * @param {PostUserInformationRequest} [postUserInformationRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async postUserInformation(postUserInformationRequest?: PostUserInformationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PostSignIn200Response>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.postUserInformation(postUserInformationRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['PostUserInformationApi.postUserInformation']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * PostUserInformationApi - factory interface
- * @export
- */
-export const PostUserInformationApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = PostUserInformationApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary Create user information
-         * @param {PostUserInformationRequest} [postUserInformationRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        postUserInformation(postUserInformationRequest?: PostUserInformationRequest, options?: any): AxiosPromise<PostSignIn200Response> {
-            return localVarFp.postUserInformation(postUserInformationRequest, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * PostUserInformationApi - object-oriented interface
- * @export
- * @class PostUserInformationApi
- * @extends {BaseAPI}
- */
-export class PostUserInformationApi extends BaseAPI {
-    /**
-     * 
-     * @summary Create user information
-     * @param {PostUserInformationRequest} [postUserInformationRequest] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof PostUserInformationApi
-     */
-    public postUserInformation(postUserInformationRequest?: PostUserInformationRequest, options?: RawAxiosRequestConfig) {
-        return PostUserInformationApiFp(this.configuration).postUserInformation(postUserInformationRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * PutAvatarApi - axios parameter creator
- * @export
- */
-export const PutAvatarApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * 
-         * @summary update avatar
-         * @param {Avatar} avatar request body of update avatar
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        putAvatar: async (avatar: Avatar, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'avatar' is not null or undefined
-            assertParamExists('putAvatar', 'avatar', avatar)
-            const localVarPath = `/avatar`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(avatar, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * PutAvatarApi - functional programming interface
- * @export
- */
-export const PutAvatarApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = PutAvatarApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary update avatar
-         * @param {Avatar} avatar request body of update avatar
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async putAvatar(avatar: Avatar, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Avatar>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.putAvatar(avatar, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['PutAvatarApi.putAvatar']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * PutAvatarApi - factory interface
- * @export
- */
-export const PutAvatarApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = PutAvatarApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary update avatar
-         * @param {Avatar} avatar request body of update avatar
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        putAvatar(avatar: Avatar, options?: any): AxiosPromise<Avatar> {
-            return localVarFp.putAvatar(avatar, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * PutAvatarApi - object-oriented interface
- * @export
- * @class PutAvatarApi
- * @extends {BaseAPI}
- */
-export class PutAvatarApi extends BaseAPI {
-    /**
-     * 
-     * @summary update avatar
-     * @param {Avatar} avatar request body of update avatar
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof PutAvatarApi
-     */
-    public putAvatar(avatar: Avatar, options?: RawAxiosRequestConfig) {
-        return PutAvatarApiFp(this.configuration).putAvatar(avatar, options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * PutChangePasswordApi - axios parameter creator
- * @export
- */
-export const PutChangePasswordApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * 
-         * @summary change password
-         * @param {PutChangePasswordRequest} [putChangePasswordRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        putChangePassword: async (putChangePasswordRequest?: PutChangePasswordRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/password`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(putChangePasswordRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * PutChangePasswordApi - functional programming interface
- * @export
- */
-export const PutChangePasswordApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = PutChangePasswordApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * 
-         * @summary change password
-         * @param {PutChangePasswordRequest} [putChangePasswordRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async putChangePassword(putChangePasswordRequest?: PutChangePasswordRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.putChangePassword(putChangePasswordRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['PutChangePasswordApi.putChangePassword']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * PutChangePasswordApi - factory interface
- * @export
- */
-export const PutChangePasswordApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = PutChangePasswordApiFp(configuration)
-    return {
-        /**
-         * 
-         * @summary change password
-         * @param {PutChangePasswordRequest} [putChangePasswordRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        putChangePassword(putChangePasswordRequest?: PutChangePasswordRequest, options?: any): AxiosPromise<void> {
-            return localVarFp.putChangePassword(putChangePasswordRequest, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * PutChangePasswordApi - object-oriented interface
- * @export
- * @class PutChangePasswordApi
- * @extends {BaseAPI}
- */
-export class PutChangePasswordApi extends BaseAPI {
-    /**
-     * 
-     * @summary change password
-     * @param {PutChangePasswordRequest} [putChangePasswordRequest] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof PutChangePasswordApi
-     */
-    public putChangePassword(putChangePasswordRequest?: PutChangePasswordRequest, options?: RawAxiosRequestConfig) {
-        return PutChangePasswordApiFp(this.configuration).putChangePassword(putChangePasswordRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-}
-
-
-
-/**
- * PutStatusApi - axios parameter creator
- * @export
- */
-export const PutStatusApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
         /**
          * 
          * @summary update status
@@ -1600,12 +684,24 @@ export const PutStatusApiAxiosParamCreator = function (configuration?: Configura
 };
 
 /**
- * PutStatusApi - functional programming interface
+ * AttendeesListApi - functional programming interface
  * @export
  */
-export const PutStatusApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = PutStatusApiAxiosParamCreator(configuration)
+export const AttendeesListApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = AttendeesListApiAxiosParamCreator(configuration)
     return {
+        /**
+         * 
+         * @summary Get attendees list
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getAttendeesList(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetAttendeesList200ResponseInner>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAttendeesList(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AttendeesListApi.getAttendeesList']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
         /**
          * 
          * @summary update status
@@ -1616,19 +712,28 @@ export const PutStatusApiFp = function(configuration?: Configuration) {
         async putStatus(status: Status, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Status>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.putStatus(status, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['PutStatusApi.putStatus']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['AttendeesListApi.putStatus']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
     }
 };
 
 /**
- * PutStatusApi - factory interface
+ * AttendeesListApi - factory interface
  * @export
  */
-export const PutStatusApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = PutStatusApiFp(configuration)
+export const AttendeesListApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = AttendeesListApiFp(configuration)
     return {
+        /**
+         * 
+         * @summary Get attendees list
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getAttendeesList(options?: any): AxiosPromise<Array<GetAttendeesList200ResponseInner>> {
+            return localVarFp.getAttendeesList(options).then((request) => request(axios, basePath));
+        },
         /**
          * 
          * @summary update status
@@ -1643,22 +748,729 @@ export const PutStatusApiFactory = function (configuration?: Configuration, base
 };
 
 /**
- * PutStatusApi - object-oriented interface
+ * AttendeesListApi - object-oriented interface
  * @export
- * @class PutStatusApi
+ * @class AttendeesListApi
  * @extends {BaseAPI}
  */
-export class PutStatusApi extends BaseAPI {
+export class AttendeesListApi extends BaseAPI {
+    /**
+     * 
+     * @summary Get attendees list
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AttendeesListApi
+     */
+    public getAttendeesList(options?: RawAxiosRequestConfig) {
+        return AttendeesListApiFp(this.configuration).getAttendeesList(options).then((request) => request(this.axios, this.basePath));
+    }
+
     /**
      * 
      * @summary update status
      * @param {Status} status request body of update status
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
-     * @memberof PutStatusApi
+     * @memberof AttendeesListApi
      */
     public putStatus(status: Status, options?: RawAxiosRequestConfig) {
-        return PutStatusApiFp(this.configuration).putStatus(status, options).then((request) => request(this.axios, this.basePath));
+        return AttendeesListApiFp(this.configuration).putStatus(status, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * AuthenticationApi - axios parameter creator
+ * @export
+ */
+export const AuthenticationApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @summary Sign in
+         * @param {PostSignInRequest} [postSignInRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postSignIn: async (postSignInRequest?: PostSignInRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/sign-in`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(postSignInRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Create user information
+         * @param {PostUserInformationRequest} [postUserInformationRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postUserInformation: async (postUserInformationRequest?: PostUserInformationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/sign-up`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(postUserInformationRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Change password
+         * @param {PutChangePasswordRequest} [putChangePasswordRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putChangePassword: async (putChangePasswordRequest?: PutChangePasswordRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/password`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(putChangePasswordRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * AuthenticationApi - functional programming interface
+ * @export
+ */
+export const AuthenticationApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = AuthenticationApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @summary Sign in
+         * @param {PostSignInRequest} [postSignInRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async postSignIn(postSignInRequest?: PostSignInRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PostSignIn200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.postSignIn(postSignInRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AuthenticationApi.postSignIn']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @summary Create user information
+         * @param {PostUserInformationRequest} [postUserInformationRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async postUserInformation(postUserInformationRequest?: PostUserInformationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PostSignIn200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.postUserInformation(postUserInformationRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AuthenticationApi.postUserInformation']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @summary Change password
+         * @param {PutChangePasswordRequest} [putChangePasswordRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async putChangePassword(putChangePasswordRequest?: PutChangePasswordRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.putChangePassword(putChangePasswordRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AuthenticationApi.putChangePassword']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * AuthenticationApi - factory interface
+ * @export
+ */
+export const AuthenticationApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = AuthenticationApiFp(configuration)
+    return {
+        /**
+         * 
+         * @summary Sign in
+         * @param {PostSignInRequest} [postSignInRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postSignIn(postSignInRequest?: PostSignInRequest, options?: any): AxiosPromise<PostSignIn200Response> {
+            return localVarFp.postSignIn(postSignInRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Create user information
+         * @param {PostUserInformationRequest} [postUserInformationRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postUserInformation(postUserInformationRequest?: PostUserInformationRequest, options?: any): AxiosPromise<PostSignIn200Response> {
+            return localVarFp.postUserInformation(postUserInformationRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Change password
+         * @param {PutChangePasswordRequest} [putChangePasswordRequest] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putChangePassword(putChangePasswordRequest?: PutChangePasswordRequest, options?: any): AxiosPromise<void> {
+            return localVarFp.putChangePassword(putChangePasswordRequest, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * AuthenticationApi - object-oriented interface
+ * @export
+ * @class AuthenticationApi
+ * @extends {BaseAPI}
+ */
+export class AuthenticationApi extends BaseAPI {
+    /**
+     * 
+     * @summary Sign in
+     * @param {PostSignInRequest} [postSignInRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AuthenticationApi
+     */
+    public postSignIn(postSignInRequest?: PostSignInRequest, options?: RawAxiosRequestConfig) {
+        return AuthenticationApiFp(this.configuration).postSignIn(postSignInRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Create user information
+     * @param {PostUserInformationRequest} [postUserInformationRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AuthenticationApi
+     */
+    public postUserInformation(postUserInformationRequest?: PostUserInformationRequest, options?: RawAxiosRequestConfig) {
+        return AuthenticationApiFp(this.configuration).postUserInformation(postUserInformationRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Change password
+     * @param {PutChangePasswordRequest} [putChangePasswordRequest] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AuthenticationApi
+     */
+    public putChangePassword(putChangePasswordRequest?: PutChangePasswordRequest, options?: RawAxiosRequestConfig) {
+        return AuthenticationApiFp(this.configuration).putChangePassword(putChangePasswordRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * AvatarListApi - axios parameter creator
+ * @export
+ */
+export const AvatarListApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @summary Get avatar list
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getAvatarList: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/avatar-list`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * AvatarListApi - functional programming interface
+ * @export
+ */
+export const AvatarListApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = AvatarListApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @summary Get avatar list
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getAvatarList(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetUserById200ResponseAvatarListInner>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAvatarList(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['AvatarListApi.getAvatarList']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * AvatarListApi - factory interface
+ * @export
+ */
+export const AvatarListApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = AvatarListApiFp(configuration)
+    return {
+        /**
+         * 
+         * @summary Get avatar list
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getAvatarList(options?: any): AxiosPromise<Array<GetUserById200ResponseAvatarListInner>> {
+            return localVarFp.getAvatarList(options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * AvatarListApi - object-oriented interface
+ * @export
+ * @class AvatarListApi
+ * @extends {BaseAPI}
+ */
+export class AvatarListApi extends BaseAPI {
+    /**
+     * 
+     * @summary Get avatar list
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AvatarListApi
+     */
+    public getAvatarList(options?: RawAxiosRequestConfig) {
+        return AvatarListApiFp(this.configuration).getAvatarList(options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * ProfileApi - axios parameter creator
+ * @export
+ */
+export const ProfileApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @summary Get a user by ID
+         * @param {number} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getUserById: async (userId: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('getUserById', 'userId', userId)
+            const localVarPath = `/users/{user_id}`
+                .replace(`{${"user_id"}}`, encodeURIComponent(String(userId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Update my avatar
+         * @param {Avatar} avatar request body of update avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putAvatar: async (avatar: Avatar, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'avatar' is not null or undefined
+            assertParamExists('putAvatar', 'avatar', avatar)
+            const localVarPath = `/avatar`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(avatar, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * ProfileApi - functional programming interface
+ * @export
+ */
+export const ProfileApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = ProfileApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @summary Get a user by ID
+         * @param {number} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getUserById(userId: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetUserById200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserById(userId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ProfileApi.getUserById']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @summary Update my avatar
+         * @param {Avatar} avatar request body of update avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async putAvatar(avatar: Avatar, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Avatar>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.putAvatar(avatar, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['ProfileApi.putAvatar']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * ProfileApi - factory interface
+ * @export
+ */
+export const ProfileApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = ProfileApiFp(configuration)
+    return {
+        /**
+         * 
+         * @summary Get a user by ID
+         * @param {number} userId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getUserById(userId: number, options?: any): AxiosPromise<GetUserById200Response> {
+            return localVarFp.getUserById(userId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Update my avatar
+         * @param {Avatar} avatar request body of update avatar
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putAvatar(avatar: Avatar, options?: any): AxiosPromise<Avatar> {
+            return localVarFp.putAvatar(avatar, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * ProfileApi - object-oriented interface
+ * @export
+ * @class ProfileApi
+ * @extends {BaseAPI}
+ */
+export class ProfileApi extends BaseAPI {
+    /**
+     * 
+     * @summary Get a user by ID
+     * @param {number} userId 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ProfileApi
+     */
+    public getUserById(userId: number, options?: RawAxiosRequestConfig) {
+        return ProfileApiFp(this.configuration).getUserById(userId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Update my avatar
+     * @param {Avatar} avatar request body of update avatar
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ProfileApi
+     */
+    public putAvatar(avatar: Avatar, options?: RawAxiosRequestConfig) {
+        return ProfileApiFp(this.configuration).putAvatar(avatar, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * RankingApi - axios parameter creator
+ * @export
+ */
+export const RankingApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @summary Get an avatar by id
+         * @param {number} count 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getAvatarById: async (count: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'count' is not null or undefined
+            assertParamExists('getAvatarById', 'count', count)
+            const localVarPath = `/avatar/{count}`
+                .replace(`{${"count"}}`, encodeURIComponent(String(count)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Get ranking
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRanking: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/ranking`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * RankingApi - functional programming interface
+ * @export
+ */
+export const RankingApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = RankingApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @summary Get an avatar by id
+         * @param {number} count 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getAvatarById(count: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetUserById200ResponseAvatarListInner>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAvatarById(count, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['RankingApi.getAvatarById']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @summary Get ranking
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getRanking(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetRanking200ResponseInner>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getRanking(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['RankingApi.getRanking']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * RankingApi - factory interface
+ * @export
+ */
+export const RankingApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = RankingApiFp(configuration)
+    return {
+        /**
+         * 
+         * @summary Get an avatar by id
+         * @param {number} count 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getAvatarById(count: number, options?: any): AxiosPromise<Array<GetUserById200ResponseAvatarListInner>> {
+            return localVarFp.getAvatarById(count, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Get ranking
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRanking(options?: any): AxiosPromise<Array<GetRanking200ResponseInner>> {
+            return localVarFp.getRanking(options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * RankingApi - object-oriented interface
+ * @export
+ * @class RankingApi
+ * @extends {BaseAPI}
+ */
+export class RankingApi extends BaseAPI {
+    /**
+     * 
+     * @summary Get an avatar by id
+     * @param {number} count 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RankingApi
+     */
+    public getAvatarById(count: number, options?: RawAxiosRequestConfig) {
+        return RankingApiFp(this.configuration).getAvatarById(count, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Get ranking
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RankingApi
+     */
+    public getRanking(options?: RawAxiosRequestConfig) {
+        return RankingApiFp(this.configuration).getRanking(options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,7 +12,7 @@ paths:
       summary: Get attendees list
       operationId: get-attendees-list
       tags:
-        - get-attendees-list
+        - Attendees list
       responses:
         "200": 
           $ref: "#/components/responses/AttendeesList"
@@ -27,7 +27,7 @@ paths:
       summary: update status
       operationId: put-status
       tags:
-        - put-status
+        - Attendees list
       requestBody:
         description: request body of update status
         required: true
@@ -48,12 +48,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /access-history:
+  /access-history/{date}:
     get:
       summary: Get access history
       operationId: get-access-history
       tags:
-        - get-access-history
+        - Access history
+      parameters:
+        - in: path
+          name: date
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           $ref: "#/components/responses/AccessHistory"
@@ -68,7 +74,7 @@ paths:
       summary: Get a user by ID
       operationId: get-user-by-id
       tags:
-        - get-user-by-id
+        - Profile
       parameters:
         - in: path
           name: user_id
@@ -87,10 +93,10 @@ paths:
                 $ref: "#/components/schemas/Error"
   /avatar:
     put:
-      summary: update avatar
+      summary: Update my avatar
       operationId: put-avatar
       tags:
-        - put-avatar
+        - Profile
       requestBody:
         description: request body of update avatar
         required: true
@@ -116,7 +122,7 @@ paths:
       summary: Get ranking
       operationId: get-ranking
       tags:
-        - get-ranking
+        - Ranking
       responses:
         "200":
           $ref: "#/components/responses/RankingList"
@@ -128,10 +134,10 @@ paths:
                 $ref: "#/components/schemas/Error"
   /avatar/{count}:
     get:
-      summary: Get an avatar by ID
+      summary: Get an avatar by id
       operationId: get-avatar-by-id
       tags:
-        - get-avatar-by-id
+        - Ranking
       parameters:
         - in: path
           name: count
@@ -153,7 +159,7 @@ paths:
       summary: Get avatar list
       operationId: get-avatar-list
       tags:
-        - get-avatar-list
+        - Avatar list
       responses:
         "200":
           $ref: "#/components/responses/AvatarInformation"
@@ -168,7 +174,7 @@ paths:
       summary: Sign in
       operationId: post-sign-in
       tags:
-        - post-sign-in
+        - Authentication
       requestBody:
         description: request body of sign in
         required: true
@@ -187,7 +193,7 @@ paths:
       summary: Create user information
       operationId: post-user-information
       tags:
-        - post-user-information
+        - Authentication
       requestBody:
         description: request body of sign up
         required: true
@@ -203,10 +209,10 @@ paths:
                 $ref: "#/components/schemas/Error"
   /password:
     put:
-      summary: change password
+      summary: Change password
       operationId: put-change-password
       tags:
-        - put-change-password
+        - Authentication
       requestBody:
         description: request body of change password
         required: true


### PR DESCRIPTION
## 背景

<!-- なぜ変更したのか -->

- Access historyページを作成するにあたって入室および退室履歴を取得するAPIを実装する

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- 初期のsqlクエリを変更（entering_historyとleaving_historyに最初の入室か最後の退室かどうかのbool型を追加）
- `GET /access-history`から`GET /access-history/:date`に変更して月毎に入退室履歴をresponseするように変更
- `GET /access-history/:date`を実装してapi設計で定義したresponseを返す

## 関連 Issue

<!-- #xxで指定 -->

- #46 

## 検証
### `GET /access-history/:date`のResponse（200）
![image](https://github.com/user-attachments/assets/c2b32164-d9ed-4ffd-b3b0-22051b726e68)

### Swagger Preview
Tagsをつけて見やすくしました．
![image](https://github.com/user-attachments/assets/4746f9a4-717d-41c3-8428-d8917d94d3de)

