### PR TITLE
入室時刻の表示ズレを修正する

### DIFF
--- a/frontend/src/routes/Home/index.tsx
+++ b/frontend/src/routes/Home/index.tsx
@@ -25,7 +25,7 @@ const decodeDate = (dateString: string) => {
   const date = dayjs(dateString);
   return `${dayjs(date).format("MM月DD日")}（${dayjs(date).format(
     "ddd"
-  )}）${dayjs(date).format("HH時MM分")}`;
+  )}）${dayjs(date).format("HH時mm分")}`;
 };
 
 type AuthUser = {


### PR DESCRIPTION
## 背景

<!-- なぜ変更したのか -->

- 表示時間が7分ずれているので修正したい

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- dayjsでdecodeするときにminutes（mm）で指定するところを、month（MM）で指定していたので修正

## 関連 Issue

<!-- #xxで指定 -->

- #56 

## 画面イメージ

<!-- frontendの実装があるときのみ -->
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/65e9aae0-b318-4ef1-8f1b-b7889c36952e">
