### PR TITLE
出席日数のランキング表示およびバグ修正

### DIFF
--- a/frontend/src/features/RankIcon/Top3Icon.tsx
+++ b/frontend/src/features/RankIcon/Top3Icon.tsx
@@ -7,15 +7,7 @@ interface Top3IconProps {
 export const Top3Icon: React.FC<Top3IconProps> = (props) => {
   const colorList = ["#ffd700", "#c9caca", "#b87333"];
   return (
-    <Box
-      zIndex={10}
-      mt={-10}
-      ml={{
-        base: 5,
-        md: 7,
-      }}
-      pb={10}
-    >
+    <Box zIndex={10} mt={-10} mr="46px" pb={10}>
       <div className="absolute">
         <FaCrown fontSize={48} color={colorList[props.rank]}></FaCrown>
       </div>

--- a/frontend/src/features/RankingList/index.tsx
+++ b/frontend/src/features/RankingList/index.tsx
@@ -80,38 +80,39 @@ export const RankingList = (placeholder: { placeholder: string }) => {
         column={3}
         row={4}
       >
-        {rankingList.slice(0, 3).map((item, index) => (
-          <GridItem
-            rowSpan={4}
-            colSpan={1}
-            textAlign="center"
-            key={index}
-            display="flex"
-            flexDirection="column"
-            justifyContent="center"
-            alignItems="center"
-          >
-            <Top3Icon rank={index}></Top3Icon>
-            <Image
-              src={`./avatar/${item.avatar_img_path}`}
-              alt={`${item.avatar_id}`}
-              boxSize={{
-                base: "48px",
-                md: "64px",
-              }}
-              cursor="pointer"
-              onClick={() =>
-                navigate("/profile", {
-                  state: { userId: item.user_id },
-                })
-              }
-            />
-            <Text>{item.user_name}</Text>
-            <Heading fontSize={{ base: "xl", md: "2xl" }} color="#fa8072">
-              {formatResultByPlaceholder(item)}
-            </Heading>
-          </GridItem>
-        ))}
+        {rankingList.length !== 0 &&
+          rankingList.slice(0, 3).map((item, index) => (
+            <GridItem
+              rowSpan={4}
+              colSpan={1}
+              textAlign="center"
+              key={index}
+              display="flex"
+              flexDirection="column"
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Top3Icon rank={index}></Top3Icon>
+              <Image
+                src={`./avatar/${item.avatar_img_path}`}
+                alt={`${item.avatar_id}`}
+                boxSize={{
+                  base: "48px",
+                  md: "64px",
+                }}
+                cursor="pointer"
+                onClick={() =>
+                  navigate("/profile", {
+                    state: { userId: item.user_id },
+                  })
+                }
+              />
+              <Text>{item.user_name}</Text>
+              <Heading fontSize={{ base: "xl", md: "2xl" }} color="#fa8072">
+                {formatResultByPlaceholder(item)}
+              </Heading>
+            </GridItem>
+          ))}
 
         <GridItem rowSpan={1} colSpan={3}>
           <TableContainer
@@ -132,63 +133,64 @@ export const RankingList = (placeholder: { placeholder: string }) => {
           >
             <Table size="sm">
               <Tbody>
-                {rankingList.slice(startIndex, endIndex).map((item, index) => (
-                  <Tr key={item.user_id}>
-                    <Td textAlign="center" w={15}>
-                      <Card>
-                        <CardBody>
-                          <Grid
-                            templateColumns="auto auto 1fr auto"
-                            alignItems={"center"}
-                            height={"20%"}
-                            w={"-moz-max-content"}
-                            gap={4}
-                          >
-                            <GridItem
-                              justifySelf="start"
-                              marginRight={{ base: 12, md: 20 }}
-                              paddingTop={14}
+                {rankingList.length !== 0 &&
+                  rankingList.slice(startIndex, endIndex).map((item, index) => (
+                    <Tr key={item.user_id}>
+                      <Td textAlign="center" w={15}>
+                        <Card>
+                          <CardBody>
+                            <Grid
+                              templateColumns="auto auto 1fr auto"
+                              alignItems={"center"}
+                              height={"20%"}
+                              w={"-moz-max-content"}
+                              gap={4}
                             >
-                              <Top10Icon rank={`${startIndex + index + 1}`} />
-                            </GridItem>
-                            <GridItem
-                              justifySelf="start"
-                              marginRight={{ base: 0, md: 8 }}
-                            >
-                              <Image
-                                src={`./avatar/${item.avatar_img_path}`}
-                                alt={`${item.avatar_id}`}
-                                boxSize={{
-                                  base: "36px",
-                                  md: "50px",
-                                }}
-                                cursor="pointer"
-                                onClick={() =>
-                                  navigate("/profile", {
-                                    state: {
-                                      userId: item.user_id,
-                                    },
-                                  })
-                                }
-                              />
-                            </GridItem>
-                            <GridItem justifySelf="start">
-                              <Text fontSize="large">{item.user_name}</Text>
-                            </GridItem>
-                            <GridItem justifySelf="end">
-                              <Heading
-                                fontSize={{ base: "xl", md: "2xl" }}
-                                color="#fa8072"
+                              <GridItem
+                                justifySelf="start"
+                                marginRight={{ base: 12, md: 20 }}
+                                paddingTop={14}
                               >
-                                {formatResultByPlaceholder(item)}
-                              </Heading>
-                            </GridItem>
-                          </Grid>
-                        </CardBody>
-                      </Card>
-                    </Td>
-                  </Tr>
-                ))}
+                                <Top10Icon rank={`${startIndex + index + 1}`} />
+                              </GridItem>
+                              <GridItem
+                                justifySelf="start"
+                                marginRight={{ base: 0, md: 8 }}
+                              >
+                                <Image
+                                  src={`./avatar/${item.avatar_img_path}`}
+                                  alt={`${item.avatar_id}`}
+                                  boxSize={{
+                                    base: "36px",
+                                    md: "50px",
+                                  }}
+                                  cursor="pointer"
+                                  onClick={() =>
+                                    navigate("/profile", {
+                                      state: {
+                                        userId: item.user_id,
+                                      },
+                                    })
+                                  }
+                                />
+                              </GridItem>
+                              <GridItem justifySelf="start">
+                                <Text fontSize="large">{item.user_name}</Text>
+                              </GridItem>
+                              <GridItem justifySelf="end">
+                                <Heading
+                                  fontSize={{ base: "xl", md: "2xl" }}
+                                  color="#fa8072"
+                                >
+                                  {formatResultByPlaceholder(item)}
+                                </Heading>
+                              </GridItem>
+                            </Grid>
+                          </CardBody>
+                        </Card>
+                      </Td>
+                    </Tr>
+                  ))}
               </Tbody>
             </Table>
           </TableContainer>

--- a/frontend/src/features/RankingList/index.tsx
+++ b/frontend/src/features/RankingList/index.tsx
@@ -65,7 +65,7 @@ export const RankingList = (placeholder: { placeholder: string }) => {
     fetchRankingList();
   }, []);
   const LIMIT_DISPLAY_RANK = 10;
-  const startIndex = 3;
+  const awardUserIndex = 3;
   const endIndex = LIMIT_DISPLAY_RANK ?? rankingList.length;
   return (
     <div>
@@ -81,7 +81,7 @@ export const RankingList = (placeholder: { placeholder: string }) => {
         row={4}
       >
         {rankingList.length !== 0 &&
-          rankingList.slice(0, 3).map((item, index) => (
+          rankingList.slice(0, awardUserIndex).map((item, index) => (
             <GridItem
               rowSpan={4}
               colSpan={1}
@@ -134,63 +134,67 @@ export const RankingList = (placeholder: { placeholder: string }) => {
             <Table size="sm">
               <Tbody>
                 {rankingList.length !== 0 &&
-                  rankingList.slice(startIndex, endIndex).map((item, index) => (
-                    <Tr key={item.user_id}>
-                      <Td textAlign="center" w={15}>
-                        <Card>
-                          <CardBody>
-                            <Grid
-                              templateColumns="auto auto 1fr auto"
-                              alignItems={"center"}
-                              height={"20%"}
-                              w={"-moz-max-content"}
-                              gap={4}
-                            >
-                              <GridItem
-                                justifySelf="start"
-                                marginRight={{ base: 12, md: 20 }}
-                                paddingTop={14}
+                  rankingList
+                    .slice(awardUserIndex, endIndex)
+                    .map((item, index) => (
+                      <Tr key={item.user_id}>
+                        <Td textAlign="center" w={15}>
+                          <Card>
+                            <CardBody>
+                              <Grid
+                                templateColumns="auto auto 1fr auto"
+                                alignItems={"center"}
+                                height={"20%"}
+                                w={"-moz-max-content"}
+                                gap={4}
                               >
-                                <Top10Icon rank={`${startIndex + index + 1}`} />
-                              </GridItem>
-                              <GridItem
-                                justifySelf="start"
-                                marginRight={{ base: 0, md: 8 }}
-                              >
-                                <Image
-                                  src={`./avatar/${item.avatar_img_path}`}
-                                  alt={`${item.avatar_id}`}
-                                  boxSize={{
-                                    base: "36px",
-                                    md: "50px",
-                                  }}
-                                  cursor="pointer"
-                                  onClick={() =>
-                                    navigate("/profile", {
-                                      state: {
-                                        userId: item.user_id,
-                                      },
-                                    })
-                                  }
-                                />
-                              </GridItem>
-                              <GridItem justifySelf="start">
-                                <Text fontSize="large">{item.user_name}</Text>
-                              </GridItem>
-                              <GridItem justifySelf="end">
-                                <Heading
-                                  fontSize={{ base: "xl", md: "2xl" }}
-                                  color="#fa8072"
+                                <GridItem
+                                  justifySelf="start"
+                                  marginRight={{ base: 12, md: 20 }}
+                                  paddingTop={14}
                                 >
-                                  {formatResultByPlaceholder(item)}
-                                </Heading>
-                              </GridItem>
-                            </Grid>
-                          </CardBody>
-                        </Card>
-                      </Td>
-                    </Tr>
-                  ))}
+                                  <Top10Icon
+                                    rank={`${awardUserIndex + index + 1}`}
+                                  />
+                                </GridItem>
+                                <GridItem
+                                  justifySelf="start"
+                                  marginRight={{ base: 0, md: 8 }}
+                                >
+                                  <Image
+                                    src={`./avatar/${item.avatar_img_path}`}
+                                    alt={`${item.avatar_id}`}
+                                    boxSize={{
+                                      base: "36px",
+                                      md: "50px",
+                                    }}
+                                    cursor="pointer"
+                                    onClick={() =>
+                                      navigate("/profile", {
+                                        state: {
+                                          userId: item.user_id,
+                                        },
+                                      })
+                                    }
+                                  />
+                                </GridItem>
+                                <GridItem justifySelf="start">
+                                  <Text fontSize="large">{item.user_name}</Text>
+                                </GridItem>
+                                <GridItem justifySelf="end">
+                                  <Heading
+                                    fontSize={{ base: "xl", md: "2xl" }}
+                                    color="#fa8072"
+                                  >
+                                    {formatResultByPlaceholder(item)}
+                                  </Heading>
+                                </GridItem>
+                              </Grid>
+                            </CardBody>
+                          </Card>
+                        </Td>
+                      </Tr>
+                    ))}
               </Tbody>
             </Table>
           </TableContainer>

--- a/frontend/src/features/RankingList/index.tsx
+++ b/frontend/src/features/RankingList/index.tsx
@@ -17,12 +17,13 @@ import { Top10Icon } from "../RankIcon/Top10Icon";
 import { useEffect, useState } from "react";
 import { GetRanking200ResponseInner } from "../../schema";
 import { rankingApi } from "../../api";
+import { useNavigate } from "react-router-dom";
 
 export const RankingList = (placeholder: { placeholder: string }) => {
-  const LIMIT_DISPLAY_RANK = 10;
   const [rankingList, setRankingList] = useState<GetRanking200ResponseInner[]>(
     []
   );
+  const navigate = useNavigate();
   const getDateFromStringFormat = (dateFormat: string) => {
     const [hours, minutes, seconds] = dateFormat.split(":").map(Number);
     const totalSeconds = hours * 3600 + minutes * 60 + seconds;
@@ -43,7 +44,7 @@ export const RankingList = (placeholder: { placeholder: string }) => {
             getDateFromStringFormat(b.stay_time)
           )
         )
-      : responseData.sort((a, b) => a.attendance_days - b.attendance_days);
+      : responseData.sort((a, b) => b.attendance_days - a.attendance_days);
   };
   const fetchRankingList = async () => {
     try {
@@ -55,11 +56,19 @@ export const RankingList = (placeholder: { placeholder: string }) => {
       console.log(error);
     }
   };
+  const formatResultByPlaceholder = (item: GetRanking200ResponseInner) => {
+    return placeholder.placeholder === "stay_time"
+      ? item.stay_time
+      : `${item.attendance_days}日`;
+  };
   useEffect(() => {
     fetchRankingList();
   }, []);
+  const LIMIT_DISPLAY_RANK = 10;
+  const startIndex = 3;
+  const endIndex = LIMIT_DISPLAY_RANK ?? rankingList.length;
   return (
-    <>
+    <div>
       <Grid
         templateColumns="repeat(3, 1fr)"
         templateRows="1fr 2fr 1fr 1fr 12fr"
@@ -71,31 +80,38 @@ export const RankingList = (placeholder: { placeholder: string }) => {
         column={3}
         row={4}
       >
-        {(() => {
-          const rankUserRender = [];
-          for (var i = 0; i < 3; i++) {
-            rankUserRender.push(
-              <GridItem rowSpan={4} colSpan={1} textAlign={"center"}>
-                <Top3Icon rank={i}></Top3Icon>
-                <Image
-                  src={`./avatar/default1.png`}
-                  alt={"default"}
-                  boxSize={{
-                    base: "48px",
-                    md: "64px",
-                  }}
-                  cursor="pointer"
-                  ml={5}
-                />
-                <Text>{rankingList[i].user_name}</Text>
-                <Heading fontSize={{ base: "xl", md: "2xl" }} color="#fa8072">
-                  {rankingList[i].stay_time}
-                </Heading>
-              </GridItem>
-            );
-          }
-          return rankUserRender;
-        })()}
+        {rankingList.slice(0, 3).map((item, index) => (
+          <GridItem
+            rowSpan={4}
+            colSpan={1}
+            textAlign="center"
+            key={index}
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Top3Icon rank={index}></Top3Icon>
+            <Image
+              src={`./avatar/${item.avatar_img_path}`}
+              alt={`${item.avatar_id}`}
+              boxSize={{
+                base: "48px",
+                md: "64px",
+              }}
+              cursor="pointer"
+              onClick={() =>
+                navigate("/profile", {
+                  state: { userId: item.user_id },
+                })
+              }
+            />
+            <Text>{item.user_name}</Text>
+            <Heading fontSize={{ base: "xl", md: "2xl" }} color="#fa8072">
+              {formatResultByPlaceholder(item)}
+            </Heading>
+          </GridItem>
+        ))}
 
         <GridItem rowSpan={1} colSpan={3}>
           <TableContainer
@@ -116,73 +132,68 @@ export const RankingList = (placeholder: { placeholder: string }) => {
           >
             <Table size="sm">
               <Tbody>
-                {(() => {
-                  const rankUserRender = [];
-                  for (
-                    var i = 3;
-                    i < LIMIT_DISPLAY_RANK ?? rankingList.length;
-                    i++
-                  ) {
-                    rankUserRender.push(
-                      <Tr key={rankingList[i].user_id}>
-                        <Td textAlign="center" w={15}>
-                          <Card>
-                            <CardBody>
-                              <Grid
-                                templateColumns="auto auto 1fr auto"
-                                alignItems={"center"}
-                                height={"20%"}
-                                w={"-moz-max-content"}
-                                gap={4}
+                {rankingList.slice(startIndex, endIndex).map((item, index) => (
+                  <Tr key={item.user_id}>
+                    <Td textAlign="center" w={15}>
+                      <Card>
+                        <CardBody>
+                          <Grid
+                            templateColumns="auto auto 1fr auto"
+                            alignItems={"center"}
+                            height={"20%"}
+                            w={"-moz-max-content"}
+                            gap={4}
+                          >
+                            <GridItem
+                              justifySelf="start"
+                              marginRight={{ base: 12, md: 20 }}
+                              paddingTop={14}
+                            >
+                              <Top10Icon rank={`${startIndex + index + 1}`} />
+                            </GridItem>
+                            <GridItem
+                              justifySelf="start"
+                              marginRight={{ base: 0, md: 8 }}
+                            >
+                              <Image
+                                src={`./avatar/${item.avatar_img_path}`}
+                                alt={`${item.avatar_id}`}
+                                boxSize={{
+                                  base: "36px",
+                                  md: "50px",
+                                }}
+                                cursor="pointer"
+                                onClick={() =>
+                                  navigate("/profile", {
+                                    state: {
+                                      userId: item.user_id,
+                                    },
+                                  })
+                                }
+                              />
+                            </GridItem>
+                            <GridItem justifySelf="start">
+                              <Text fontSize="large">{item.user_name}</Text>
+                            </GridItem>
+                            <GridItem justifySelf="end">
+                              <Heading
+                                fontSize={{ base: "xl", md: "2xl" }}
+                                color="#fa8072"
                               >
-                                <GridItem
-                                  justifySelf="start"
-                                  marginRight={{ base: 12, md: 20 }}
-                                  paddingTop={14}
-                                >
-                                  <Top10Icon rank={`${i + 1}`} />
-                                </GridItem>
-                                <GridItem
-                                  justifySelf="start"
-                                  marginRight={{ base: 0, md: 8 }}
-                                >
-                                  <Image
-                                    src={`./avatar/${rankingList[i].avatar_img_path}`}
-                                    alt={`${rankingList[i].avatar_id}`}
-                                    boxSize={{
-                                      base: "36px",
-                                      md: "50px",
-                                    }}
-                                    cursor="pointer"
-                                  />
-                                </GridItem>
-                                <GridItem justifySelf="start">
-                                  <Text fontSize="large">
-                                    {rankingList[i].user_name}
-                                  </Text>
-                                </GridItem>
-                                <GridItem justifySelf="end">
-                                  <Heading
-                                    fontSize={{ base: "xl", md: "2xl" }}
-                                    color="#fa8072"
-                                  >
-                                    {rankingList[i].stay_time}
-                                  </Heading>
-                                </GridItem>
-                              </Grid>
-                            </CardBody>
-                          </Card>
-                        </Td>
-                      </Tr>
-                    );
-                  }
-                  return rankUserRender;
-                })()}
+                                {formatResultByPlaceholder(item)}
+                              </Heading>
+                            </GridItem>
+                          </Grid>
+                        </CardBody>
+                      </Card>
+                    </Td>
+                  </Tr>
+                ))}
               </Tbody>
             </Table>
           </TableContainer>
         </GridItem>
       </Grid>
-    </>
+    </div>
   );
 };

--- a/frontend/src/routes/Ranking/index.tsx
+++ b/frontend/src/routes/Ranking/index.tsx
@@ -31,10 +31,10 @@ export const Ranking = () => {
         <Tab>出席日数</Tab>
       </TabList>
       <TabPanels>
-        <TabPanel>
+        <TabPanel key={"stay_time"}>
           <RankingList placeholder="stay_time"></RankingList>
         </TabPanel>
-        <TabPanel>
+        <TabPanel key={"attendance_days"}>
           <RankingList placeholder="attendance_days"></RankingList>
         </TabPanel>
       </TabPanels>


### PR DESCRIPTION
## 背景

<!-- なぜ変更したのか -->

- 出席日数をAPIから取得することはできたが、画面がまだだったので実装

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- 出席日数を各ユーザ取得し、その総和を降順で表示する
- APIでの処理が完了しておらずランキングリストが空の場合はレンダリングしないようにする
- ランキングのアバターにアクセス履歴と同じclickイベントを追加する

## 関連 Issue

<!-- #xxで指定 -->

- #50 
- #102 
- #103 

## 画面イメージ

<!-- frontendの実装があるときのみ -->
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/350d161c-69f4-4ff3-b341-42431c6c66f1">
