### PR TITLE
LAシフトボードを入力する画面を作成する

### DIFF
--- a/backend/internal/schema/model_get_lab_assistant_member_200_response_inner.go
+++ b/backend/internal/schema/model_get_lab_assistant_member_200_response_inner.go
@@ -19,6 +19,8 @@ type GetLabAssistantMember200ResponseInner struct {
 
 	AvatarImgPath string `json:"avatar_img_path"`
 
+	LastShiftDate string `json:"last_shift_date"`
+
 	Count int32 `json:"count"`
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,8 @@
         "axios": "^1.7.2",
         "dayjs": "^1.11.11",
         "framer-motion": "^4.1.17",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^2.5.1",
         "mdb-react-ui-kit": "^8.0.0",
         "react": "^18.3.1",
         "react-datepicker": "^7.3.0",
@@ -5982,6 +5984,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
       "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
+    },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -6978,6 +6986,17 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
@@ -7352,6 +7371,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7560,6 +7587,17 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -7691,6 +7729,31 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -8346,6 +8409,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -9080,6 +9151,12 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.6.tgz",
+      "integrity": "sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==",
+      "optional": true
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -10349,6 +10426,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -11394,6 +11476,18 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -14545,6 +14639,23 @@
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -18235,6 +18346,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -18927,6 +19047,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -19440,6 +19569,15 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -19708,6 +19846,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -20266,6 +20412,14 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
     "axios": "^1.7.2",
     "dayjs": "^1.11.11",
     "framer-motion": "^4.1.17",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1",
     "mdb-react-ui-kit": "^8.0.0",
     "react": "^18.3.1",
     "react-datepicker": "^7.3.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Home from "./routes/Home";
 import AccessHistory from "./routes/AccessHistory";
 import Profile from "./routes/Profile";
 import SignInWebauthn from "./routes/SignInWebauthn";
+import LabAssistant from "./routes/LabAssistant";
 import Footer from "./features/Footer";
 import SidebarContent from "./features/SidebarContent";
 import MobileNav from "./features/MobileNav";
@@ -59,6 +60,7 @@ const App = () => {
                 <Route path="/profile" element={<Profile />} />
                 <Route path="/ranking" element={<Ranking />} />
                 <Route path="/sign-in-webauthn" element={<SignInWebauthn />} />
+                <Route path="/lab-assistant" element={<LabAssistant />} />
               </Routes>
             </Box>
           </Box>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,7 @@ import {
   ProfileApi,
   AccessHistoryApi,
   RankingApi,
+  LAApi,
 } from "./schema";
 
 const baseURL = process.env.REACT_APP_BACKEND_ENDPOINT;
@@ -15,5 +16,6 @@ const attendeesListApi = new AttendeesListApi(undefined, baseURL, api);
 const profileApi = new ProfileApi(undefined, baseURL, api);
 const accessHistoryApi = new AccessHistoryApi(undefined, baseURL, api);
 const rankingApi = new RankingApi(undefined, baseURL, api);
+const labAssistantApi = new LAApi(undefined, baseURL, api);
 
-export { attendeesListApi, profileApi, accessHistoryApi, rankingApi };
+export { attendeesListApi, profileApi, accessHistoryApi, rankingApi, labAssistantApi };

--- a/frontend/src/features/SidebarContent/index.tsx
+++ b/frontend/src/features/SidebarContent/index.tsx
@@ -6,6 +6,7 @@ import { IconType } from "react-icons";
 import { FiHome, FiBarChart2, FiMapPin, FiSettings } from "react-icons/fi";
 import { FaHistory } from "react-icons/fa";
 import { GiPerspectiveDiceSixFacesRandom } from "react-icons/gi";
+import { ImLab } from "react-icons/im";
 
 interface SidebarProps extends BoxProps {
   onClose: () => void;
@@ -17,6 +18,7 @@ const LinkItems: Array<{ name: string; icon: IconType; href: string }> = [
   { name: "Ranking", icon: FiBarChart2, href: "/ranking" },
   { name: "Gacha", icon: GiPerspectiveDiceSixFacesRandom, href: "/" },
   { name: "ISDL Map", icon: FiMapPin, href: "/" },
+  { name: "LA", icon: ImLab, href: "/lab-assistant" },
   { name: "Settings", icon: FiSettings, href: "/" },
 ];
 

--- a/frontend/src/routes/LabAssistant/index.tsx
+++ b/frontend/src/routes/LabAssistant/index.tsx
@@ -1,0 +1,384 @@
+import React, { useState, useEffect, ChangeEvent, useRef } from "react";
+import {
+  Box,
+  Flex,
+  Grid,
+  Select,
+  Text,
+  Button,
+  chakra,
+  useToast,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Avatar,
+  TableContainer,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from "@chakra-ui/react";
+import dayjs from "dayjs";
+import "dayjs/locale/ja";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import html2canvas from "html2canvas";
+import jsPDF from "jspdf";
+import { labAssistantApi } from "../../api";
+import {
+  GetLabAssistantMember200ResponseInner,
+  GetLabAssistantSchedule200ResponseInner,
+  PostLabAssistantScheduleRequestInner,
+} from "../../schema";
+import { useNavigate } from "react-router-dom";
+
+dayjs.locale("ja");
+
+interface Shift {
+  date: number;
+  user_name: string;
+}
+
+const generateDaysInMonth = (year: number, month: number): Shift[] => {
+  const startOfMonth = dayjs().year(year).month(month).startOf("month");
+  const endOfMonth = dayjs().year(year).month(month).endOf("month");
+  const daysInMonth: Shift[] = [];
+
+  for (let i = 0; i < startOfMonth.day(); i++) {
+    daysInMonth.push({
+      date: 0,
+      user_name: "",
+    });
+  }
+
+  for (
+    let date = startOfMonth;
+    date.isBefore(endOfMonth) || date.isSame(endOfMonth);
+    date = date.add(1, "day")
+  ) {
+    daysInMonth.push({
+      date: date.date(),
+      user_name: "",
+    });
+  }
+  return daysInMonth;
+};
+
+const formatMonth = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+};
+
+const fetchLabAssistantData = async (
+  selectedDate: Date | null,
+  selectedYear: number,
+  selectedMonth: number,
+  setLabAssistantMember: React.Dispatch<React.SetStateAction<GetLabAssistantMember200ResponseInner[]>>,
+  setShifts: React.Dispatch<React.SetStateAction<Shift[]>>,
+  labAssistantApi: any
+) => {
+  const memberResponse = await labAssistantApi.getLabAssistantMember();
+  setLabAssistantMember(memberResponse.data);
+
+  const formattedMonth = formatMonth(selectedDate || new Date());
+  const scheduleResponse = await labAssistantApi.getLabAssistantSchedule(formattedMonth);
+
+  const updatedShifts = generateDaysInMonth(
+    selectedYear,
+    selectedMonth
+  ).map((shift) => {
+    const schedule = scheduleResponse.data?.find(
+      (s: GetLabAssistantSchedule200ResponseInner) =>
+        dayjs(s.shift_date).date() === shift.date
+    );
+    return schedule ? { ...shift, user_name: schedule.user_name } : shift;
+  });
+
+  setShifts(updatedShifts);
+};
+
+export default function Profile() {
+  const [selectedYear, setSelectedYear] = useState<number>(dayjs().year());
+  const [selectedMonth, setSelectedMonth] = useState<number>(dayjs().month());
+  const [shifts, setShifts] = useState<Shift[]>(
+    generateDaysInMonth(selectedYear, selectedMonth)
+  );
+  const [labAssistantMember, setLabAssistantMember] = useState<
+    GetLabAssistantMember200ResponseInner[]
+  >([]);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
+  const toast = useToast();
+  const navigate = useNavigate();
+  const gridRef = useRef<HTMLDivElement>(null); 
+  const titleRef = useRef<HTMLDivElement>(null); 
+
+  useEffect(() => {
+    fetchLabAssistantData(
+      selectedDate,
+      selectedYear,
+      selectedMonth,
+      setLabAssistantMember,
+      setShifts,
+      labAssistantApi
+    );
+  }, [selectedYear, selectedMonth]);
+
+  const handleMonthChange = (date: Date | null) => {
+    if (date) {
+      setSelectedYear(dayjs(date).year());
+      setSelectedMonth(dayjs(date).month());
+      setShifts(generateDaysInMonth(dayjs(date).year(), dayjs(date).month()));
+      setSelectedDate(date);
+    }
+  };
+
+  const handleNameChange = (
+    index: number,
+    event: ChangeEvent<HTMLSelectElement>
+  ) => {
+    const newShifts = [...shifts];
+    newShifts[index].user_name = event.target.value;
+    setShifts(newShifts);
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const requestBody: PostLabAssistantScheduleRequestInner[] = shifts
+        .filter((shift) => shift.date !== 0 && shift.user_name !== "")
+        .map((shift) => {
+          const member = labAssistantMember.find(
+            (m) => m.user_name === shift.user_name
+          );
+          return {
+            user_id: member?.user_id || 0,
+            shift_date: dayjs(
+              `${selectedYear}-${selectedMonth + 1}-${shift.date}`
+            ).format("YYYY-MM-DD"),
+          };
+        });
+
+      const formattedMonth = formatMonth(selectedDate || new Date());
+      await labAssistantApi.postLabAssistantSchedule(
+        formattedMonth,
+        requestBody
+      );
+
+      await fetchLabAssistantData(
+        selectedDate,
+        selectedYear,
+        selectedMonth,
+        setLabAssistantMember,
+        setShifts,
+        labAssistantApi
+      );
+      
+      toast({
+        title: "シフトが正常に登録されました。",
+        status: "success",
+        duration: 5000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: "シフトの登録に失敗しました。",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handlePdfDownload = async () => {
+    const titleElement = titleRef.current;
+    const gridElement = gridRef.current;
+  
+    if (!titleElement || !gridElement) {
+      console.error('Element not found');
+      return;
+    }
+  
+    const titleCanvas = await html2canvas(titleElement, { scale: 2 });
+  
+    const gridCanvas = await html2canvas(gridElement, { scale: 2 });
+  
+    const titleImgData = titleCanvas.toDataURL('image/png');
+    const gridImgData = gridCanvas.toDataURL('image/png');
+    const pdf = new jsPDF('landscape');
+  
+    const titleFontSize = 16;
+    pdf.setFontSize(titleFontSize);
+    
+    const titleWidth = 50;
+    const titleHeight = 10;
+    
+    const titleX = (pdf.internal.pageSize.width - 210) / 2;
+    const titleY = 40;
+  
+    pdf.addImage(titleImgData, 'PNG', titleX, titleY, titleWidth, titleHeight);
+  
+    const imgWidth = 210; 
+    const imgHeight = gridCanvas.height * imgWidth / gridCanvas.width;
+  
+    const gridX = (pdf.internal.pageSize.width - imgWidth) / 2;
+    const gridY = titleY + titleHeight;
+  
+    pdf.addImage(gridImgData, 'PNG', gridX, gridY, imgWidth, imgHeight);
+  
+    const filename = `${selectedYear}${String(selectedMonth + 1).padStart(2, '0')}.pdf`;
+    pdf.save(filename);
+  };
+  
+  
+
+  return (
+    <Box>
+      <Tabs>
+        <TabList>
+          <Tab>シフトボード</Tab>
+          <Tab>シフトメンバー</Tab>
+        </TabList>
+
+        <TabPanels>
+          <TabPanel>
+            {/* シフトボード */}
+            <Flex
+              flexDirection="row"
+              mb={3}
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Box ref={titleRef}>
+                <Text fontSize="xl" fontWeight="bold" mb={3} textAlign="left">
+                  {`${selectedYear}年度${selectedMonth + 1}月LAシフト表`}
+                </Text>
+              </Box>
+              <Flex alignItems="center" gap={4}>
+                <chakra.label htmlFor="month-picker" fontWeight="bold">
+                  月を選択:
+                </chakra.label>
+                <DatePicker
+                  selected={selectedDate}
+                  onChange={handleMonthChange}
+                  dateFormat="yyyy/MM"
+                  showMonthYearPicker
+                  id="month-picker"
+                  className="custom-datepicker"
+                />
+                <Button colorScheme="blue" onClick={handlePdfDownload}>
+                  PDF化
+                </Button>
+                <Button colorScheme="teal" onClick={handleSubmit}>
+                  登録
+                </Button>
+              </Flex>
+            </Flex>
+
+            <Box ref={gridRef}>
+              <Grid templateColumns="repeat(7, 1fr)" gap={1} mt={4}>
+                {["日", "月", "火", "水", "木", "金", "土"].map(
+                  (day, index) => (
+                    <Box
+                      key={index}
+                      p={2}
+                      bg="rgba(79, 209, 197, 1)"
+                      textAlign="center"
+                    >
+                      {day}
+                    </Box>
+                  )
+                )}
+                {shifts.map((shift, index) => (
+                  <Box
+                    key={index}
+                    p={2}
+                    border="1px solid"
+                    borderColor="gray.200"
+                    bg={shift.date === 0 ? "transparent" : "white"}
+                  >
+                    {shift.date !== 0 && (
+                      <>
+                        <Text mb={2} textAlign="center">
+                          {shift.date}日
+                        </Text>
+                        <Select
+                          value={shift.user_name}
+                          onChange={(event) => handleNameChange(index, event)}
+                          placeholder=" "
+                        >
+                          {labAssistantMember.map((member) => (
+                            <option
+                              key={member.user_id}
+                              value={member.user_name}
+                            >
+                              {member.user_name}
+                            </option>
+                          ))}
+                        </Select>
+                      </>
+                    )}
+                  </Box>
+                ))}
+              </Grid>
+            </Box>
+          </TabPanel>
+
+          <TabPanel>
+            <TableContainer
+              pb={14}
+              pr={{ base: 2, md: 14 }}
+              pl={{ base: 2, md: 14 }}
+              mt={8}
+              outlineOffset={2}
+              overflowX="unset"
+              overflowY="scroll"
+              height="65vh"
+            >
+              <Table
+                size="lg"
+                border="2px"
+                borderColor="gray.200"
+                variant="simple"
+              >
+                <Thead>
+                  <Tr bgColor="#E6EBED">
+                    <Th>ユーザー</Th>
+                    <Th>最終LA日程</Th>
+                    <Th>LA回数</Th>
+                  </Tr>
+                </Thead>
+                <Tbody outline="1px">
+                  {labAssistantMember.map((member) => (
+                    <Tr key={member.user_id}>
+                      <Td>
+                        <Flex alignItems="center" gap={3}>
+                          <Avatar
+                            size={"md"}
+                            src={`./avatar/${member.avatar_img_path}`}
+                            border="2px"
+                            onClick={() =>
+                              navigate("/profile", {
+                                state: { userId: member.user_id },
+                              })
+                            }
+                          />
+                          {member.user_name}
+                        </Flex>
+                      </Td>
+                      <Td>{member.last_shift_date}</Td>
+                      <Td>{member.count}</Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            </TableContainer>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}

--- a/frontend/src/routes/LabAssistant/index.tsx
+++ b/frontend/src/routes/LabAssistant/index.tsx
@@ -68,6 +68,13 @@ const generateDaysInMonth = (year: number, month: number): Shift[] => {
   return daysInMonth;
 };
 
+const decodeDate = (dateString: string) => {
+  const date = dayjs(dateString);
+  return `${dayjs(date).format("YYYY年MM月DD日")}（${dayjs(date).format(
+    "ddd"
+  )})`;
+};
+
 const formatMonth = (date: Date) => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -369,7 +376,7 @@ export default function Profile() {
                           {member.user_name}
                         </Flex>
                       </Td>
-                      <Td>{member.last_shift_date}</Td>
+                      <Td>{decodeDate(member.last_shift_date)}</Td>
                       <Td>{member.count}</Td>
                     </Tr>
                   ))}

--- a/frontend/src/routes/LabAssistant/index.tsx
+++ b/frontend/src/routes/LabAssistant/index.tsx
@@ -85,7 +85,9 @@ const fetchLabAssistantData = async (
   selectedDate: Date | null,
   selectedYear: number,
   selectedMonth: number,
-  setLabAssistantMember: React.Dispatch<React.SetStateAction<GetLabAssistantMember200ResponseInner[]>>,
+  setLabAssistantMember: React.Dispatch<
+    React.SetStateAction<GetLabAssistantMember200ResponseInner[]>
+  >,
   setShifts: React.Dispatch<React.SetStateAction<Shift[]>>,
   labAssistantApi: any
 ) => {
@@ -93,18 +95,19 @@ const fetchLabAssistantData = async (
   setLabAssistantMember(memberResponse.data);
 
   const formattedMonth = formatMonth(selectedDate || new Date());
-  const scheduleResponse = await labAssistantApi.getLabAssistantSchedule(formattedMonth);
+  const scheduleResponse = await labAssistantApi.getLabAssistantSchedule(
+    formattedMonth
+  );
 
-  const updatedShifts = generateDaysInMonth(
-    selectedYear,
-    selectedMonth
-  ).map((shift) => {
-    const schedule = scheduleResponse.data?.find(
-      (s: GetLabAssistantSchedule200ResponseInner) =>
-        dayjs(s.shift_date).date() === shift.date
-    );
-    return schedule ? { ...shift, user_name: schedule.user_name } : shift;
-  });
+  const updatedShifts = generateDaysInMonth(selectedYear, selectedMonth).map(
+    (shift) => {
+      const schedule = scheduleResponse.data?.find(
+        (s: GetLabAssistantSchedule200ResponseInner) =>
+          dayjs(s.shift_date).date() === shift.date
+      );
+      return schedule ? { ...shift, user_name: schedule.user_name } : shift;
+    }
+  );
 
   setShifts(updatedShifts);
 };
@@ -121,8 +124,8 @@ export default function Profile() {
   const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
   const toast = useToast();
   const navigate = useNavigate();
-  const gridRef = useRef<HTMLDivElement>(null); 
-  const titleRef = useRef<HTMLDivElement>(null); 
+  const gridRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetchLabAssistantData(
@@ -183,7 +186,7 @@ export default function Profile() {
         setShifts,
         labAssistantApi
       );
-      
+
       toast({
         title: "シフトが正常に登録されました。",
         status: "success",
@@ -203,48 +206,49 @@ export default function Profile() {
   const handlePdfDownload = async () => {
     const titleElement = titleRef.current;
     const gridElement = gridRef.current;
-  
+
     if (!titleElement || !gridElement) {
-      console.error('Element not found');
+      console.error("Element not found");
       return;
     }
-  
+
     const titleCanvas = await html2canvas(titleElement, { scale: 2 });
-  
+
     const gridCanvas = await html2canvas(gridElement, { scale: 2 });
-  
-    const titleImgData = titleCanvas.toDataURL('image/png');
-    const gridImgData = gridCanvas.toDataURL('image/png');
-    const pdf = new jsPDF('landscape');
-  
+
+    const titleImgData = titleCanvas.toDataURL("image/png");
+    const gridImgData = gridCanvas.toDataURL("image/png");
+    const pdf = new jsPDF("landscape");
+
     const titleFontSize = 16;
     pdf.setFontSize(titleFontSize);
-    
+
     const titleWidth = 50;
     const titleHeight = 10;
-    
+
     const titleX = (pdf.internal.pageSize.width - 210) / 2;
     const titleY = 40;
-  
-    pdf.addImage(titleImgData, 'PNG', titleX, titleY, titleWidth, titleHeight);
-  
-    const imgWidth = 210; 
-    const imgHeight = gridCanvas.height * imgWidth / gridCanvas.width;
-  
+
+    pdf.addImage(titleImgData, "PNG", titleX, titleY, titleWidth, titleHeight);
+
+    const imgWidth = 210;
+    const imgHeight = (gridCanvas.height * imgWidth) / gridCanvas.width;
+
     const gridX = (pdf.internal.pageSize.width - imgWidth) / 2;
     const gridY = titleY + titleHeight;
-  
-    pdf.addImage(gridImgData, 'PNG', gridX, gridY, imgWidth, imgHeight);
-  
-    const filename = `${selectedYear}${String(selectedMonth + 1).padStart(2, '0')}.pdf`;
+
+    pdf.addImage(gridImgData, "PNG", gridX, gridY, imgWidth, imgHeight);
+
+    const filename = `${selectedYear}${String(selectedMonth + 1).padStart(
+      2,
+      "0"
+    )}.pdf`;
     pdf.save(filename);
   };
-  
-  
 
   return (
     <Box>
-      <Tabs>
+      <Tabs mt={{ base: 20, md: 0 }}>
         <TabList>
           <Tab>シフトボード</Tab>
           <Tab>シフトメンバー</Tab>
@@ -252,19 +256,31 @@ export default function Profile() {
 
         <TabPanels>
           <TabPanel>
-            {/* シフトボード */}
             <Flex
               flexDirection="row"
               mb={3}
               alignItems="center"
               justifyContent="space-between"
+              flexWrap="wrap" // モバイル対応
             >
-              <Box ref={titleRef}>
-                <Text fontSize="xl" fontWeight="bold" mb={3} textAlign="left">
+              <Box ref={titleRef} flex="1">
+                <Text
+                  fontSize="xl"
+                  fontWeight="bold"
+                  mb={3}
+                  whiteSpace="nowrap"
+                >
                   {`${selectedYear}年${selectedMonth + 1}月LAシフト表`}
                 </Text>
               </Box>
-              <Flex alignItems="center" gap={4}>
+              <Flex
+                alignItems="center"
+                gap={4}
+                justifyContent={{ base: "center", md: "flex-end" }} // 中央揃え
+                flex="1"
+                mt={{ base: 4, md: 0 }} // モバイルでの余白調整
+                flexWrap="wrap" // モバイル対応
+              >
                 <chakra.label htmlFor="month-picker" fontWeight="bold">
                   月を選択:
                 </chakra.label>
@@ -285,8 +301,13 @@ export default function Profile() {
               </Flex>
             </Flex>
 
-            <Box ref={gridRef}>
-              <Grid templateColumns="repeat(7, 1fr)" gap={1} mt={4}>
+            <Box ref={gridRef} overflowX="auto">
+              <Grid
+                templateColumns="repeat(7, 1fr)"
+                gap={1}
+                mt={4}
+                minWidth="600px"
+              >
                 {["日", "月", "火", "水", "木", "金", "土"].map(
                   (day, index) => (
                     <Box
@@ -341,9 +362,9 @@ export default function Profile() {
               pl={{ base: 2, md: 14 }}
               mt={8}
               outlineOffset={2}
-              overflowX="unset"
-              overflowY="scroll"
+              overflowX="auto"
               height="65vh"
+              maxWidth="100%" // テーブルをPCに合わせる
             >
               <Table
                 size="lg"

--- a/frontend/src/routes/LabAssistant/index.tsx
+++ b/frontend/src/routes/LabAssistant/index.tsx
@@ -254,7 +254,7 @@ export default function Profile() {
             >
               <Box ref={titleRef}>
                 <Text fontSize="xl" fontWeight="bold" mb={3} textAlign="left">
-                  {`${selectedYear}年度${selectedMonth + 1}月LAシフト表`}
+                  {`${selectedYear}年${selectedMonth + 1}月LAシフト表`}
                 </Text>
               </Box>
               <Flex alignItems="center" gap={4}>

--- a/frontend/src/schema/api.ts
+++ b/frontend/src/schema/api.ts
@@ -234,6 +234,12 @@ export interface GetLabAssistantMember200ResponseInner {
     'avatar_img_path': string;
     /**
      * 
+     * @type {string}
+     * @memberof GetLabAssistantMember200ResponseInner
+     */
+    'last_shift_date': string;
+    /**
+     * 
      * @type {number}
      * @memberof GetLabAssistantMember200ResponseInner
      */

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1123,7 +1123,7 @@
   resolved "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.21.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.21.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.24.8"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz"
   integrity sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==
@@ -3177,6 +3177,11 @@
   resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz"
   integrity sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==
 
+"@types/raf@^3.4.0":
+  version "3.4.3"
+  resolved "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz"
+  integrity sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==
+
 "@types/range-parser@*":
   version "1.2.7"
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz"
@@ -3903,6 +3908,11 @@ at-least-node@^1.0.0:
   resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
+atob@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
 autoprefixer@^10.4.13:
   version "10.4.19"
   resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz"
@@ -4093,6 +4103,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
@@ -4213,6 +4228,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
@@ -4294,6 +4314,20 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001640:
   version "1.0.30001641"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz"
   integrity sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==
+
+canvg@^3.0.6:
+  version "3.0.10"
+  resolved "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz"
+  integrity sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/raf" "^3.4.0"
+    core-js "^3.8.3"
+    raf "^3.4.1"
+    regenerator-runtime "^0.13.7"
+    rgbcolor "^1.0.1"
+    stackblur-canvas "^2.0.0"
+    svg-pathdata "^6.0.3"
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -4640,7 +4674,7 @@ core-js-pure@^3.23.3:
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.37.1.tgz"
   integrity sha512-J/r5JTHSmzTxbiYYrzXg9w1VpqrYt+gexenBE9pugeyhwPZTAEJddyiReJWsLO6uNQ8xJZFbod6XC7KKwatCiA==
 
-core-js@^3.19.2:
+core-js@^3.19.2, core-js@^3.6.0, core-js@^3.8.3:
   version "3.37.1"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz"
   integrity sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==
@@ -4711,6 +4745,13 @@ css-has-pseudo@^3.0.4:
   integrity sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==
   dependencies:
     postcss-selector-parser "^6.0.9"
+
+css-line-break@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz"
+  integrity sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==
+  dependencies:
+    utrie "^1.0.2"
 
 css-loader@^6.5.1:
   version "6.11.0"
@@ -5186,6 +5227,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+dompurify@^2.2.0:
+  version "2.5.6"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-2.5.6.tgz"
+  integrity sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==
 
 domutils@^1.7.0:
   version "1.7.0"
@@ -5916,6 +5962,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fflate@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
+
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz"
@@ -6483,6 +6534,14 @@ html-webpack-plugin@^5.5.0:
     lodash "^4.17.21"
     pretty-error "^4.0.0"
     tapable "^2.0.0"
+
+html2canvas@^1.0.0-rc.5, html2canvas@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz"
+  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
 
 htmlparser2@^6.1.0:
   version "6.1.0"
@@ -7685,6 +7744,21 @@ jsonpointer@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz"
   integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
+
+jspdf@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz"
+  integrity sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
+    atob "^2.1.2"
+    btoa "^1.2.1"
+    fflate "^0.4.8"
+  optionalDependencies:
+    canvg "^3.0.6"
+    core-js "^3.6.0"
+    dompurify "^2.2.0"
+    html2canvas "^1.0.0-rc.5"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"
@@ -9583,7 +9657,7 @@ regenerate@^1.4.2:
   resolved "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.9:
+regenerator-runtime@^0.13.7, regenerator-runtime@^0.13.9:
   version "0.13.11"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
@@ -9733,6 +9807,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rgbcolor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz"
+  integrity sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==
 
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
@@ -10158,6 +10237,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackblur-canvas@^2.0.0:
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz"
+  integrity sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==
+
 stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz"
@@ -10427,6 +10511,11 @@ svg-parser@^2.0.2:
   resolved "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
+svg-pathdata@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz"
+  integrity sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==
+
 svgo@^1.2.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz"
@@ -10559,6 +10648,13 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+text-segmentation@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz"
+  integrity sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==
+  dependencies:
+    utrie "^1.0.2"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -10951,6 +11047,13 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+utrie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz"
+  integrity sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==
+  dependencies:
+    base64-arraybuffer "^1.0.2"
 
 uuid@^8.3.2:
   version "8.3.2"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -543,6 +543,8 @@ components:
                   format: uint64
                 avatar_img_path:
                   type: string
+                last_shift_date:
+                  type: string
                 count:
                   type: integer
                   format: uint64
@@ -551,6 +553,7 @@ components:
                 - user_name
                 - avatar_id
                 - avatar_img_path
+                - last_shift_date
                 - count
     LabAssistantSchedule:
       description: Successful to get lab assistant schedule


### PR DESCRIPTION
## 背景

<!-- なぜ変更したのか -->

- LAシフトボードを入力する画面を作成する
- memberを取得するAPIに最後に行ったLA日程（last_shift_day）を追加する

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- apiスキーマの更新（last_shift_day）
- lab_assistant_member_repository.goの修正
- LAシフト表のページ作成
- LAシフト表のPDF化

### 機能
- 初回レンダリング時は今月のLAを表示
- カレンダーは月に合わせて正しい日にちと曜日になる
- 選択形式でメンバーを選択し，「登録ボタン」をクリックするとDBに登録完了
- 変更したい場合も同様に「登録ボタン」をクリックすると変更を反映
- 「PDF化ボタン」をクリックするとシフト表をPDF化可能
- LAメンバーには名前，最終LA日程，LA回数を表示

## 関連 Issue
- #85 
- #109 

## 画面イメージ
### シフトボード
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/553c8bc2-9f73-4a3f-85cc-e9960071431b">

### LAメンバー
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/adcfd3de-56bf-44df-be2d-90bd911b3b6e">

### U4のみ選択可能
<img width="286" alt="image" src="https://github.com/user-attachments/assets/d2fa5006-54c3-424a-8b55-0f3bf67d306e">

### PDF化
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/bf2b4352-1ead-47cb-ad76-23e25a77b94c">


