### PR TITLE
calendarAPIの全件取得にKC101【小教室】のカレンダーIDを追加する

### DIFF
--- a/backend/internal/infrastructures/calendar.go
+++ b/backend/internal/infrastructures/calendar.go
@@ -179,6 +179,7 @@ func GetCalendarList() []model.Calendar {
 	var eventList []model.Calendar
 	calendarIDs := []model.CalendarRoomId{
 		model.CalendarRoomId{RoomName: "KC101-large", CalendarId: model.KC101_LARGE_CALENDAR_ID},
+		model.CalendarRoomId{RoomName: "KC101-small", CalendarId: model.KC101_SMALL_CALENDAR_ID},
 		model.CalendarRoomId{RoomName: "KC103", CalendarId: model.KC103_CALENDAR_ID},
 		model.CalendarRoomId{RoomName: "KC111", CalendarId: model.KC111_CALENDAR_ID},
 		model.CalendarRoomId{RoomName: "KC116", CalendarId: model.KC116_CALENDAR_ID},

--- a/backend/internal/models/calendar.go
+++ b/backend/internal/models/calendar.go
@@ -15,6 +15,7 @@ type CalendarRoomId struct {
 
 const (
 	KC101_LARGE_CALENDAR_ID = "mikilab.doshisha.ac.jp_3739313235333736353437@resource.calendar.google.com"
+	KC101_SMALL_CALENDAR_ID = "c_188c9tphie1akjm2hquasoipu060q@resource.calendar.google.com"
 	KC103_CALENDAR_ID       = "mikilab.doshisha.ac.jp_33353234353936362d333132@resource.calendar.google.com"
 	KC111_CALENDAR_ID       = "mikilab.doshisha.ac.jp_3235333239333534343633@resource.calendar.google.com"
 	KC116_CALENDAR_ID       = "mikilab.doshisha.ac.jp_38363338373137302d343939@resource.calendar.google.com"

--- a/database/sqls/init_tables.sql
+++ b/database/sqls/init_tables.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS user(
     password VARCHAR(64) NOT NULL,
     number_of_coin INT NOT NULL,
     display_name VARCHAR(64),
+    current_entered_at DATETIME,
     status_id INT UNSIGNED NOT NULL,
     place_id INT UNSIGNED,
     grade_id INT UNSIGNED NOT NULL,


### PR DESCRIPTION
## 背景

<!-- なぜ変更したのか -->

- GoogleCalendarアプリ上からKC101【小教室】のカレンダーIDを確認できなかったため、calendarAPIで予定を取得する時にKC101【小教室】の分だけ取得できていない

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- 一斉取得の処理にKC101【小教室】のカレンダーIDを追加する
- userテーブルにentered_atを設ける（今後のタスクのため。差分少ないので一緒にやってます）

## 関連 Issue

<!-- #xxで指定 -->

- #115 
- #117 

## 画面イメージ

<!-- frontendの実装があるときのみ -->
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/ff15271d-711c-4a2a-86e5-dbcc8803aa9b">
