### PR TITLE
calendarAPIの処理待ちにLoading画面を正しく表示する

### DIFF
--- a/frontend/src/features/Loading/Loading.tsx
+++ b/frontend/src/features/Loading/Loading.tsx
@@ -1,0 +1,19 @@
+import { Spinner, Text } from "@chakra-ui/react";
+
+export const Loading = (loadingItemText: { loadingItemText: string }) => {
+  return (
+    <>
+      <Text pb={3} fontWeight={800} fontSize={{ base: 16, md: 20 }}>
+        {loadingItemText.loadingItemText}を読込中です
+      </Text>
+      <Spinner
+        thickness="4px"
+        speed="0.65s"
+        emptyColor="gray.200"
+        color="teal.500"
+        size="xl"
+        alignContent={"center"}
+      />
+    </>
+  );
+};

--- a/frontend/src/routes/Home/index.tsx
+++ b/frontend/src/routes/Home/index.tsx
@@ -22,6 +22,7 @@ import { GetAttendeesList200ResponseInner } from "../../schema";
 import { useEffect, useState } from "react";
 import { useUser } from "../../userContext";
 import { useNavigate } from "react-router-dom";
+import { Loading } from "../../features/Loading/Loading";
 
 dayjs.locale("ja");
 
@@ -156,17 +157,7 @@ function Home() {
           <Tbody outline="1px">
             {isFetching ? (
               <Td colSpan={5} textAlign="center">
-                <Text pb={3} fontWeight={800} fontSize={20}>
-                  出席者を読込中です
-                </Text>
-                <Spinner
-                  thickness="4px"
-                  speed="0.65s"
-                  emptyColor="gray.200"
-                  color="teal.500"
-                  size="xl"
-                  alignContent={"center"}
-                />
+                <Loading loadingItemText="出席者"></Loading>
               </Td>
             ) : attendeeList === null ? (
               <Tr>

--- a/frontend/src/routes/Home/index.tsx
+++ b/frontend/src/routes/Home/index.tsx
@@ -3,10 +3,12 @@ import {
   Button,
   Flex,
   Grid,
+  Spinner,
   Table,
   TableContainer,
   Tbody,
   Td,
+  Text,
   Th,
   Thead,
   Tr,
@@ -18,8 +20,8 @@ import { inRoom } from "../../models/users/user";
 import { attendeesListApi } from "../../api";
 import { GetAttendeesList200ResponseInner } from "../../schema";
 import { useEffect, useState } from "react";
-import { useUser } from '../../userContext';
-import { useNavigate } from 'react-router-dom';
+import { useUser } from "../../userContext";
+import { useNavigate } from "react-router-dom";
 
 dayjs.locale("ja");
 
@@ -32,13 +34,18 @@ const decodeDate = (dateString: string) => {
 
 function Home() {
   const { authUser, setAuthUser } = useUser();
-  const [attendeeList, setAttendeeList] = useState<GetAttendeesList200ResponseInner[] | null>(null);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+  const [attendeeList, setAttendeeList] = useState<
+    GetAttendeesList200ResponseInner[] | null
+  >(null);
   const navigate = useNavigate();
 
   const fetchAttendeesList = async () => {
     try {
+      setIsFetching(true);
       const response = await attendeesListApi.getAttendeesList();
       setAttendeeList(response.data);
+      setIsFetching(false);
     } catch (error) {
       console.log(error);
     }
@@ -53,7 +60,7 @@ function Home() {
       });
       setAuthUser({
         ...authUser,
-        status: user.data.status
+        status: user.data.status,
       });
       await fetchAttendeesList(); // ここでリストを再取得
     } catch (error) {
@@ -147,7 +154,21 @@ function Home() {
             </Tr>
           </Thead>
           <Tbody outline="1px">
-            {attendeeList === null ? (
+            {isFetching ? (
+              <Td colSpan={5} textAlign="center">
+                <Text pb={3} fontWeight={800} fontSize={20}>
+                  出席者を読込中です
+                </Text>
+                <Spinner
+                  thickness="4px"
+                  speed="0.65s"
+                  emptyColor="gray.200"
+                  color="teal.500"
+                  size="xl"
+                  alignContent={"center"}
+                />
+              </Td>
+            ) : attendeeList === null ? (
               <Tr>
                 <Td colSpan={5} textAlign="center">
                   出席者はいません
@@ -162,7 +183,11 @@ function Home() {
                         size={"md"}
                         src={attendee.avatar_img_path}
                         border="2px"
-                        onClick={() => navigate("/profile", { state: { userId: attendee.user_id } })}
+                        onClick={() =>
+                          navigate("/profile", {
+                            state: { userId: attendee.user_id },
+                          })
+                        }
                       ></Avatar>
                       {attendee.user_name}
                     </Flex>


### PR DESCRIPTION
## 背景

<!-- なぜ変更したのか -->

- 出席者一覧を取得する際に、取得前は「出席者はいません」と表示される仕様だが、calendarAPIの追加によって応答時間が長くなってしまったので、目立つしなんとかしたい

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- APIから応答待ちの時は出席者一覧にその文言を表示する

## 関連 Issue

<!-- #xxで指定 -->

- #116 

## 画面イメージ

<!-- frontendの実装があるときのみ -->
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/d367df36-53f1-4f46-ad90-ff219cd19033">
