### PR TITLE
Setting画面のデザインを実装する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import MobileNav from "./features/MobileNav";
 import { useDisclosure } from "@chakra-ui/react";
 import { Ranking } from "./routes/Ranking";
 import { UserProvider } from "./userContext"; // Import UserProvider
+import { UserSetting } from "./routes/UserSetting";
 
 const App = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -63,6 +64,7 @@ const App = () => {
                 <Route path="/sign-in-webauthn" element={<SignInWebauthn />} />
                 <Route path="/lab-assistant" element={<LabAssistant />} />
                 <Route path="/sign-in-digest" element={<SignInDigest />} />
+                <Route path="/user-setting" element={<UserSetting />} />
               </Routes>
             </Box>
           </Box>

--- a/frontend/src/features/RoleBadge/index.tsx
+++ b/frontend/src/features/RoleBadge/index.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "@chakra-ui/react";
+
+export const RoleBadge = (role: { text: string }) => {
+  const getColorScheme = (role: string) => {
+    switch (role) {
+      case "chief":
+        return "red";
+      case "infra":
+        return "yellow";
+      default:
+        return "blue";
+    }
+  };
+  return (
+    <Badge
+      m={1}
+      borderRadius="full"
+      fontSize="16px"
+      px="10px"
+      py="4px"
+      colorScheme={getColorScheme(role.text)}
+    >
+      {role.text}
+    </Badge>
+  );
+};

--- a/frontend/src/features/SettingInfo/index.tsx
+++ b/frontend/src/features/SettingInfo/index.tsx
@@ -1,0 +1,99 @@
+import {
+  Avatar,
+  Card,
+  Divider,
+  Flex,
+  IconButton,
+  Text,
+} from "@chakra-ui/react";
+import { UserInfo } from "../../routes/UserSetting";
+import { useNavigate } from "react-router-dom";
+import { RoleBadge } from "../RoleBadge";
+import { EditIcon } from "@chakra-ui/icons";
+
+interface SettingInfoProps {
+  userInfo: UserInfo[];
+  targetUserId: number;
+}
+export const SettingInfo: React.FC<SettingInfoProps> = ({
+  userInfo,
+  targetUserId,
+}) => {
+  const navigate = useNavigate();
+  const targetUserInfo = userInfo.find((user) => user.user_id === targetUserId);
+  return (
+    <Card mb={{ base: "0px", lg: "20px" }} alignItems="center" p="30px">
+      <Flex minHeight="15vh">
+        <Flex
+          alignItems="center"
+          width="100%"
+          maxWidth="800px"
+          gap={12}
+          mb="20px"
+        >
+          <Avatar
+            size={"xl"}
+            src={targetUserInfo?.avatar_img_path}
+            border="2px"
+            onClick={() =>
+              navigate("/profile", {
+                state: { userId: targetUserInfo?.user_id },
+              })
+            }
+          />
+          <Flex flexDirection="column" alignItems="flex-start" flex={1}>
+            <Text fontWeight="bold" fontSize="2xl" mb="10px">
+              {targetUserInfo?.name}
+            </Text>
+            <Text fontSize="md" fontWeight="400">
+              メールアドレス: {targetUserInfo?.mail_address}
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Divider
+        borderColor="rgba(79, 209, 197, 1)"
+        borderWidth="3px"
+        mb="30px"
+      />
+      <Flex flexDirection="column" gap={5}>
+        <Flex alignItems="center" gap={10}>
+          <Text fontWeight="bold" fontSize="xl" width="80px">
+            学年:
+          </Text>
+          <Text fontSize="xl" fontWeight="400">
+            {targetUserInfo?.grade}
+          </Text>
+        </Flex>
+        <Flex alignItems="center" gap={10}>
+          <Text fontWeight="bold" fontSize="xl" width="80px">
+            役割:
+          </Text>
+          <Flex flexWrap="wrap" gap={2}>
+            {targetUserInfo && targetUserInfo.role.length > 0 ? (
+              targetUserInfo?.role.map((role, index) => (
+                <RoleBadge key={index} text={role} />
+              ))
+            ) : (
+              <Text fontSize="xl" fontWeight="400">
+                担当はありません
+              </Text>
+            )}
+          </Flex>
+        </Flex>
+      </Flex>
+      <IconButton
+        aria-label="Change Avatar"
+        icon={<EditIcon />}
+        variant="ghost"
+        colorScheme="teal"
+        size="lg"
+        position="absolute"
+        bottom="2"
+        right="2"
+        fontSize="32px"
+        m={6}
+      />
+    </Card>
+  );
+};

--- a/frontend/src/features/SidebarContent/index.tsx
+++ b/frontend/src/features/SidebarContent/index.tsx
@@ -16,10 +16,8 @@ const LinkItems: Array<{ name: string; icon: IconType; href: string }> = [
   { name: "Attendee List", icon: FiHome, href: "/" },
   { name: "Access History", icon: FaHistory, href: "/access-history" },
   { name: "Ranking", icon: FiBarChart2, href: "/ranking" },
-  { name: "Gacha", icon: GiPerspectiveDiceSixFacesRandom, href: "/" },
-  { name: "ISDL Map", icon: FiMapPin, href: "/" },
   { name: "LA", icon: ImLab, href: "/lab-assistant" },
-  { name: "Settings", icon: FiSettings, href: "/" },
+  { name: "Settings", icon: FiSettings, href: "/user-setting" },
 ];
 
 const SidebarContent = ({ onClose, ...rest }: SidebarProps) => {
@@ -32,7 +30,7 @@ const SidebarContent = ({ onClose, ...rest }: SidebarProps) => {
       w={{ base: "full", md: 60 }}
       pos="fixed"
       h="full"
-      zIndex="0" // SidebarContentを前面に表示
+      zIndex="0"
       {...rest}
     >
       <Flex h="6" alignItems="center" mx="8" justifyContent="space-between">

--- a/frontend/src/features/UserList/index.tsx
+++ b/frontend/src/features/UserList/index.tsx
@@ -1,0 +1,106 @@
+import {
+  Avatar,
+  Box,
+  Card,
+  Checkbox,
+  Divider,
+  Flex,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
+import { UserInfo } from "../../routes/UserSetting";
+import { useNavigate } from "react-router-dom";
+import { Dispatch, SetStateAction } from "react";
+
+interface UserListProps {
+  userInfo: UserInfo[];
+  setTargetUserId: Dispatch<SetStateAction<number>>;
+}
+
+export const UserList: React.FC<UserListProps> = ({
+  userInfo,
+  setTargetUserId,
+}) => {
+  const navigate = useNavigate();
+  const changeUser = (userId: number) => {
+    setTargetUserId(userId);
+  };
+  return (
+    <Card mb={{ base: "0px", lg: "20px" }} alignItems="center">
+      <Box
+        width="100%"
+        height="100%"
+        display="flex"
+        flexDirection="column"
+        justifyContent="space-between"
+        overflowY="scroll"
+      >
+        <Box flex="1" m="15px">
+          <Flex
+            alignItems="center"
+            justifyContent="space-between"
+            width="100%"
+            mb="10px"
+          >
+            <Text fontSize="2xl" fontWeight="bold">
+              ユーザ一覧
+            </Text>
+            <Flex alignItems="center" gap={3}>
+              <Checkbox type="checkbox" />
+              <Text fontSize="sm" fontWeight="bold">
+                卒業済みユーザの表示
+              </Text>
+            </Flex>
+          </Flex>
+          <Divider
+            borderColor="rgba(79, 209, 197, 1)"
+            borderWidth="3px"
+            mb="10px"
+          />
+          <Box overflowY="auto" maxHeight="65vh">
+            <Table variant="simple" size={{ base: "sm", md: "md" }}>
+              <Thead>
+                <Tr>
+                  <Th textAlign="center">ユーザ名</Th>
+                  <Th textAlign="center">学年</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {userInfo.map((info, index) => (
+                  <Tr
+                    key={info.user_id}
+                    onClick={() => changeUser(info.user_id)}
+                  >
+                    <Td textAlign="center">
+                      <Flex alignItems={"center"} gap={3}>
+                        <Box position="relative">
+                          <Avatar
+                            size={"md"}
+                            src={info.avatar_img_path}
+                            border="2px"
+                            onClick={() =>
+                              navigate("/profile", {
+                                state: { userId: info.user_id },
+                              })
+                            }
+                          />
+                        </Box>
+                        {info.name}
+                      </Flex>
+                    </Td>
+                    <Td textAlign="center">{info.grade}</Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </Box>
+        </Box>
+      </Box>
+    </Card>
+  );
+};

--- a/frontend/src/routes/Home/index.tsx
+++ b/frontend/src/routes/Home/index.tsx
@@ -4,7 +4,6 @@ import {
   Flex,
   Grid,
   Box,
-  Spinner,
   Table,
   TableContainer,
   Tbody,
@@ -28,8 +27,8 @@ import { useNavigate } from "react-router-dom";
 import { Loading } from "../../features/Loading/Loading";
 
 const buttonWidth = {
-  base: "100px", 
-  md: "150px",   
+  base: "100px",
+  md: "150px",
 };
 
 dayjs.locale("ja");
@@ -98,7 +97,12 @@ function Home() {
 
   return (
     <div>
-      <Grid templateColumns="repeat(1, 1fr)" w="100%" mt={{ base: 20, md: 0 }} p={6}>
+      <Grid
+        templateColumns="repeat(1, 1fr)"
+        w="100%"
+        mt={{ base: 20, md: 0 }}
+        p={6}
+      >
         <Flex justifyContent="center" alignItems="center" w="100%">
           <Box flex="1">
             <Text
@@ -123,36 +127,84 @@ function Home() {
           >
             {authUser.status === overnight ? (
               <>
-                <Button w={buttonWidth} colorScheme="cyan" variant="solid" size="lg" isDisabled>
+                <Button
+                  w={buttonWidth}
+                  colorScheme="cyan"
+                  variant="solid"
+                  size="lg"
+                  isDisabled
+                >
                   宿泊済
                 </Button>
-                <Button w={buttonWidth} colorScheme="teal" variant="solid" size="lg" isDisabled>
+                <Button
+                  w={buttonWidth}
+                  colorScheme="teal"
+                  variant="solid"
+                  size="lg"
+                  isDisabled
+                >
                   入室済
                 </Button>
-                <Button w={buttonWidth} colorScheme="teal" variant="solid" size="lg" onClick={() => handleStatusChange(outRoom)}>
+                <Button
+                  w={buttonWidth}
+                  colorScheme="teal"
+                  variant="solid"
+                  size="lg"
+                  onClick={() => handleStatusChange(outRoom)}
+                >
                   退室
                 </Button>
               </>
             ) : authUser.status === inRoom ? (
               <>
                 {isBetween8PMandMidnight() && (
-                  <Button w={buttonWidth} colorScheme="cyan" variant="solid" size="lg" onClick={() => handleStatusChange(overnight)}>
+                  <Button
+                    w={buttonWidth}
+                    colorScheme="cyan"
+                    variant="solid"
+                    size="lg"
+                    onClick={() => handleStatusChange(overnight)}
+                  >
                     宿泊
                   </Button>
                 )}
-                <Button w={buttonWidth} colorScheme="teal" variant="solid" size="lg" isDisabled>
+                <Button
+                  w={buttonWidth}
+                  colorScheme="teal"
+                  variant="solid"
+                  size="lg"
+                  isDisabled
+                >
                   入室済
                 </Button>
-                <Button w={buttonWidth} colorScheme="teal" variant="solid" size="lg" onClick={() => handleStatusChange(outRoom)}>
+                <Button
+                  w={buttonWidth}
+                  colorScheme="teal"
+                  variant="solid"
+                  size="lg"
+                  onClick={() => handleStatusChange(outRoom)}
+                >
                   退室
                 </Button>
               </>
             ) : (
               <>
-                <Button w={buttonWidth} colorScheme="teal" variant="solid" size="lg" onClick={() => handleStatusChange(inRoom)}>
+                <Button
+                  w={buttonWidth}
+                  colorScheme="teal"
+                  variant="solid"
+                  size="lg"
+                  onClick={() => handleStatusChange(inRoom)}
+                >
                   入室
                 </Button>
-                <Button w={buttonWidth} colorScheme="teal" variant="solid" size="lg" isDisabled>
+                <Button
+                  w={buttonWidth}
+                  colorScheme="teal"
+                  variant="solid"
+                  size="lg"
+                  isDisabled
+                >
                   退室済
                 </Button>
               </>
@@ -161,7 +213,16 @@ function Home() {
         )}
       </Grid>
 
-      <TableContainer pb={14} pr={{ base: 4, md: 14 }} pl={{ base: 4, md: 14 }} mt={8} outlineOffset={2} overflowX="unset" overflowY="scroll" height="65vh">
+      <TableContainer
+        pb={14}
+        pr={{ base: 4, md: 14 }}
+        pl={{ base: 4, md: 14 }}
+        mt={8}
+        outlineOffset={2}
+        overflowX="unset"
+        overflowY="scroll"
+        height="65vh"
+      >
         <Table size="lg" border="2px" borderColor="gray.200" variant="simple">
           <Thead top={0}>
             <Tr bgColor="#E6EBED">

--- a/frontend/src/routes/UserSetting/index.tsx
+++ b/frontend/src/routes/UserSetting/index.tsx
@@ -1,0 +1,126 @@
+import { Box, Grid } from "@chakra-ui/react";
+import { useState } from "react";
+import { UserList } from "../../features/UserList";
+import { SettingInfo } from "../../features/SettingInfo";
+
+// モック用
+// backendの実装が完了したら消す
+export type UserInfo = {
+  user_id: number;
+  name: string;
+  mail_address: string;
+  grade: string;
+  avatar_img_path: string;
+  role: string[];
+};
+const userInfo: UserInfo[] = [
+  {
+    user_id: 1,
+    name: "酒部健太郎",
+    mail_address: "sakabe.kentaro@mikilab.doshisha.ac.jp",
+    grade: "M2",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["infra", "kc111"],
+  },
+  {
+    user_id: 3,
+    name: "岡颯人",
+    mail_address: "oka.hayato@mikilab.doshisha.ac.jp",
+    grade: "M2",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["chief", "event"],
+  },
+  {
+    user_id: 5,
+    name: "花本凪",
+    mail_address: "hanamoto.nagi@mikilab.doshisha.ac.jp",
+    grade: "OB",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["infra"],
+  },
+  {
+    user_id: 5,
+    name: "花本凪",
+    mail_address: "hanamoto.nagi@mikilab.doshisha.ac.jp",
+    grade: "OB",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["infra"],
+  },
+  {
+    user_id: 5,
+    name: "花本凪",
+    mail_address: "hanamoto.nagi@mikilab.doshisha.ac.jp",
+    grade: "OB",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["infra"],
+  },
+  {
+    user_id: 5,
+    name: "花本凪",
+    mail_address: "hanamoto.nagi@mikilab.doshisha.ac.jp",
+    grade: "OB",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["infra"],
+  },
+  {
+    user_id: 5,
+    name: "花本凪",
+    mail_address: "hanamoto.nagi@mikilab.doshisha.ac.jp",
+    grade: "OB",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["infra"],
+  },
+  {
+    user_id: 5,
+    name: "花本凪",
+    mail_address: "hanamoto.nagi@mikilab.doshisha.ac.jp",
+    grade: "OB",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["infra"],
+  },
+  {
+    user_id: 5,
+    name: "花本凪",
+    mail_address: "hanamoto.nagi@mikilab.doshisha.ac.jp",
+    grade: "OB",
+    avatar_img_path:
+      "https://drive.google.com/thumbnail?id=1E2HnYLTvg9XXVeW1gMbANAvCbl_ES6Nn&sz=w1000",
+    role: ["infra"],
+  },
+];
+
+export const UserSetting = () => {
+  const [targetUserId, setTargetUserId] = useState(userInfo[0].user_id);
+  return (
+    <Box pt={{ base: "80px", md: "80px", xl: "10px" }}>
+      <Grid
+        templateColumns={{
+          base: "1fr",
+          lg: "0.6fr 1fr",
+        }}
+        templateRows={{
+          base: "repeat(2, 1fr)",
+          lg: "1fr",
+        }}
+        gap={{ base: "20px", xl: "20px" }}
+      >
+        <UserList
+          userInfo={userInfo}
+          setTargetUserId={setTargetUserId}
+        ></UserList>
+        <SettingInfo
+          userInfo={userInfo}
+          targetUserId={targetUserId}
+        ></SettingInfo>
+      </Grid>
+    </Box>
+  );
+};


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

- #157 

## 変更内容（やること）

<!-- 変更内容、実現すること -->
- Setting画面のデザインを実装
- ユーザ一覧にあるユーザを選択すると右側にその情報を表示
- **今回実装をしないであろう機能はサイドバーから削除**
---
下記の理由から一覧にOBを含めるかどうかの処理、実際の編集モードは未実装
- コードが長いしレビューがしんどい（見落とす）
- デザインを固めてから実装に移りたい
- https://github.com/ISDL-dev/ISDL-Sentinel/pull/171 において役割一覧をAPIから取得するかを検討中なので、その部分の実装も保留して現在の進捗を共有するため

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->
- 概ねFigmaのデザインで作成できていることを確認しました
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/9c1133bd-620b-4222-8011-e4a805ce22dd">

- 一覧で選択した際該当ユーザの情報が表示できることを確認しました
