### PR TITLE
各画面をユーザのroleに基づく表示にする

### DIFF
--- a/frontend/src/features/SettingInfo/index.tsx
+++ b/frontend/src/features/SettingInfo/index.tsx
@@ -21,6 +21,8 @@ import { ChangeEvent, useState } from "react";
 import { FaCheck } from "react-icons/fa";
 import { settingApi } from "../../api";
 import { GetUsersInfo200ResponseInner } from "../../schema";
+import { useUser } from "../../userContext";
+import { isChief } from "../../models/role/role";
 
 interface SettingInfoProps {
   userInfo: GetUsersInfo200ResponseInner[];
@@ -41,6 +43,7 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
   fetchUserList,
 }) => {
   const navigate = useNavigate();
+  const { authUser } = useUser();
   const targetUserInfo =
     userInfo.find((user) => user.user_id === targetUserId) ?? userInfo[0];
   const [changePendingUserInfo, setChangePendingUserInfo] =
@@ -194,57 +197,58 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
           </Box>
         )}
       </Flex>
-      {isEditing ? (
-        <Flex position="absolute" bottom="2" right="2" gap={4} m={6}>
-          <Button
-            w={buttonWidth}
-            colorScheme="gray"
-            variant="solid"
+      {isChief(authUser) &&
+        (isEditing ? (
+          <Flex position="absolute" bottom="2" right="2" gap={4} m={6}>
+            <Button
+              w={buttonWidth}
+              colorScheme="gray"
+              variant="solid"
+              size="lg"
+              onClick={() => {
+                setChangePendingUserInfo({
+                  ...targetUserInfo,
+                  role_list: targetUserInfo.role_list || [],
+                });
+                setIsEditing(false);
+              }}
+            >
+              キャンセル
+            </Button>
+            <Button
+              w={buttonWidth}
+              colorScheme="teal"
+              variant="solid"
+              size="lg"
+              onClick={() => {
+                setIsEditing(false);
+                submitUserInfo();
+              }}
+            >
+              更新
+            </Button>
+          </Flex>
+        ) : (
+          <IconButton
+            aria-label="Change Avatar"
+            icon={<EditIcon />}
+            variant="ghost"
+            colorScheme="teal"
             size="lg"
+            position="absolute"
+            bottom="2"
+            right="2"
+            fontSize="32px"
+            m={6}
             onClick={() => {
               setChangePendingUserInfo({
                 ...targetUserInfo,
                 role_list: targetUserInfo.role_list || [],
               });
-              setIsEditing(false);
+              setIsEditing(true);
             }}
-          >
-            キャンセル
-          </Button>
-          <Button
-            w={buttonWidth}
-            colorScheme="teal"
-            variant="solid"
-            size="lg"
-            onClick={() => {
-              setIsEditing(false);
-              submitUserInfo();
-            }}
-          >
-            更新
-          </Button>
-        </Flex>
-      ) : (
-        <IconButton
-          aria-label="Change Avatar"
-          icon={<EditIcon />}
-          variant="ghost"
-          colorScheme="teal"
-          size="lg"
-          position="absolute"
-          bottom="2"
-          right="2"
-          fontSize="32px"
-          m={6}
-          onClick={() => {
-            setChangePendingUserInfo({
-              ...targetUserInfo,
-              role_list: targetUserInfo.role_list || [],
-            });
-            setIsEditing(true);
-          }}
-        />
-      )}
+          />
+        ))}
     </Card>
   );
 };

--- a/frontend/src/models/role/role.ts
+++ b/frontend/src/models/role/role.ts
@@ -1,0 +1,10 @@
+import { AuthUser } from "../../userContext";
+
+export const CHIEF = "チーフ";
+export const INFRA = "インフラ";
+export const isChief = (authUser?: AuthUser) => {
+  return authUser && (authUser.role_list.includes(CHIEF) ?? []);
+};
+export const isInfra = (authUser?: AuthUser) => {
+  return authUser && (authUser.role_list.includes(INFRA) ?? []);
+};

--- a/frontend/src/routes/LabAssistant/index.tsx
+++ b/frontend/src/routes/LabAssistant/index.tsx
@@ -35,6 +35,8 @@ import {
   PostLabAssistantScheduleRequestInner,
 } from "../../schema";
 import { useNavigate } from "react-router-dom";
+import { useUser } from "../../userContext";
+import { isInfra } from "../../models/role/role";
 
 dayjs.locale("ja");
 
@@ -113,6 +115,7 @@ const fetchLabAssistantData = async (
 };
 
 export default function Profile() {
+  const { authUser } = useUser();
   const [selectedYear, setSelectedYear] = useState<number>(dayjs().year());
   const [selectedMonth, setSelectedMonth] = useState<number>(dayjs().month());
   const [shifts, setShifts] = useState<Shift[]>(
@@ -295,9 +298,11 @@ export default function Profile() {
                 <Button colorScheme="blue" onClick={handlePdfDownload}>
                   PDF化
                 </Button>
-                <Button colorScheme="teal" onClick={handleSubmit}>
-                  登録
-                </Button>
+                {isInfra(authUser) && (
+                  <Button colorScheme="teal" onClick={handleSubmit}>
+                    登録
+                  </Button>
+                )}
               </Flex>
             </Flex>
 
@@ -333,20 +338,26 @@ export default function Profile() {
                         <Text mb={2} textAlign="center">
                           {shift.date}日
                         </Text>
-                        <Select
-                          value={shift.user_name}
-                          onChange={(event) => handleNameChange(index, event)}
-                          placeholder=" "
-                        >
-                          {labAssistantMember.map((member) => (
-                            <option
-                              key={member.user_id}
-                              value={member.user_name}
-                            >
-                              {member.user_name}
-                            </option>
-                          ))}
-                        </Select>
+                        {isInfra(authUser) ? (
+                          <Select
+                            value={shift.user_name}
+                            onChange={(event) => handleNameChange(index, event)}
+                            placeholder=" "
+                          >
+                            {labAssistantMember.map((member) => (
+                              <option
+                                key={member.user_id}
+                                value={member.user_name}
+                              >
+                                {member.user_name}
+                              </option>
+                            ))}
+                          </Select>
+                        ) : (
+                          <Text mb={2} textAlign="center">
+                            {shift.user_name}
+                          </Text>
+                        )}
                       </>
                     )}
                   </Box>

--- a/frontend/src/userContext.tsx
+++ b/frontend/src/userContext.tsx
@@ -1,14 +1,13 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect } from "react";
 
-interface AuthUser {
+export interface AuthUser {
   user_id: number;
   user_name: string;
   status: string;
   role_list: string[];
   avatar_id: number;
-  avatar_img_path: string;  
+  avatar_img_path: string;
 }
-
 
 interface UserContextType {
   authUser: AuthUser | undefined;
@@ -17,17 +16,19 @@ interface UserContextType {
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
-export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   const [authUser, setAuthUser] = useState<AuthUser | undefined>(() => {
-    const savedUser = localStorage.getItem('auth_user');
+    const savedUser = localStorage.getItem("auth_user");
     return savedUser ? JSON.parse(savedUser) : undefined;
   });
 
   useEffect(() => {
     if (authUser) {
-      localStorage.setItem('auth_user', JSON.stringify(authUser));
+      localStorage.setItem("auth_user", JSON.stringify(authUser));
     } else {
-      localStorage.removeItem('auth_user');
+      localStorage.removeItem("auth_user");
     }
   }, [authUser]);
 
@@ -41,7 +42,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
 export const useUser = () => {
   const context = useContext(UserContext);
   if (context === undefined) {
-    throw new Error('useUser must be used within a UserProvider');
+    throw new Error("useUser must be used within a UserProvider");
   }
   return context;
 };


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

- #159 

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- LAの画面はRoleにinfraがないユーザの場合、メンバーを変更できないようにする
- Setting画面はRoleにchefがないユーザの場合、メンバーの権限を変更できないようにする

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->

- LAとsettingの権限を適用できていることを確認しました

### インフラ担当の場合
<img width="1463" alt="スクリーンショット 2024-10-12 22 53 56" src="https://github.com/user-attachments/assets/9e7d78ee-74d2-41dd-9057-0a5568fbb630">

### インフラ担当ではない場合
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/e899ed7e-12e8-4219-b2d9-48189a56553a">

### チーフ担当の場合
<img width="1460" alt="image" src="https://github.com/user-attachments/assets/69e47237-7d3e-456b-9bc4-384356c44a52">

### チーフ担当ではない場合
<img width="1462" alt="image" src="https://github.com/user-attachments/assets/a3037cc6-a5e2-4a00-a6f3-e18dcc673721">

