### PR TITLE
gradeが「OB」のユーザはSetting以外の機能で無効化する

### DIFF
--- a/backend/internal/repositories/attendees_list_repository.go
+++ b/backend/internal/repositories/attendees_list_repository.go
@@ -60,7 +60,8 @@ func GetInRoomUserListRepository(inRoomStatusId int32) (userList []schema.GetAtt
 				user_id
 		) eh ON u.id = eh.user_id
 	WHERE 
-		s.status_name IN (?, ?);`
+		s.status_name IN (?, ?)
+		AND g.grade_name != 'OB';`
 	getRows, err := infrastructures.DB.Query(getInRoomUserListQuery, model.KC104, model.IN_ROOM, model.OVERNIGHT)
 	if err != nil {
 		return []schema.GetAttendeesList200ResponseInner{}, fmt.Errorf("getRows getInRoomUserList Query error err:%w", err)

--- a/backend/internal/repositories/ranking_repository.go
+++ b/backend/internal/repositories/ranking_repository.go
@@ -40,6 +40,8 @@ func GetRankingRepository() (rankingList []schema.GetRanking200ResponseInner, er
 			entering_history
 		GROUP BY 
 			user_id) e ON u.id = e.user_id
+	WHERE
+		g.grade_name != 'OB'
 	ORDER BY 
 		u.id;`
 


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

- #169 

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- 出席者に表示させないようにする（念の為）
- ランキングのための情報をAPIから取得の際にOBは含めない

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->
- gradeがOBのdummyユーザを作成
<img width="690" alt="スクリーンショット 2024-10-12 23 31 20" src="https://github.com/user-attachments/assets/3c350b70-39d6-40d6-94f3-ce51e36ad26d">

- dummyが出席しても出席者一覧に表示されないことを確認しました
<img width="1460" alt="スクリーンショット 2024-10-12 23 34 07" src="https://github.com/user-attachments/assets/36073bdc-0c5f-441b-969a-a6c830bc2118">

- ランキングに表示できる順位でもOBの場合は表示されないことを確認しました
<img width="1456" alt="スクリーンショット 2024-10-12 23 34 37" src="https://github.com/user-attachments/assets/e48903e8-19dc-4388-8749-fe78bbe1427d">

