### PR TITLE
Setting画面のUI/UX改善を行う

### DIFF
--- a/frontend/src/features/RoleBadge/index.tsx
+++ b/frontend/src/features/RoleBadge/index.tsx
@@ -15,7 +15,7 @@ export const RoleBadge = (role: { text: string }) => {
     <Badge
       m={1}
       borderRadius="full"
-      fontSize="16px"
+      fontSize={{ base: "10px", md: "16px" }}
       px="10px"
       py="4px"
       colorScheme={getColorScheme(role.text)}

--- a/frontend/src/features/SettingInfo/index.tsx
+++ b/frontend/src/features/SettingInfo/index.tsx
@@ -13,6 +13,7 @@ import {
   Td,
   Text,
   Tr,
+  useToast,
 } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { RoleBadge } from "../RoleBadge";
@@ -30,7 +31,7 @@ interface SettingInfoProps {
   fetchUserList: () => Promise<void>;
 }
 const buttonWidth = {
-  base: "100px",
+  base: "80px",
   md: "150px",
 };
 export const SettingInfo: React.FC<SettingInfoProps> = ({
@@ -41,6 +42,7 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
   fetchUserList,
 }) => {
   const navigate = useNavigate();
+  const toast = useToast();
   const targetUserInfo =
     userInfo.find((user) => user.user_id === targetUserId) ?? userInfo[0];
   const [changePendingUserInfo, setChangePendingUserInfo] =
@@ -66,26 +68,48 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
     return changePendingUserInfo.role_list.includes(role);
   };
   const submitUserInfo = async () => {
-    await settingApi.putUserById(changePendingUserInfo.user_id, {
-      user_name: changePendingUserInfo.user_name,
-      grade: changePendingUserInfo.grade,
-      mail_address: changePendingUserInfo.mail_address,
-      role_list: changePendingUserInfo.role_list,
-    });
-    fetchUserList();
+    try {
+      await settingApi.putUserById(changePendingUserInfo.user_id, {
+        user_name: changePendingUserInfo.user_name,
+        grade: changePendingUserInfo.grade,
+        mail_address: changePendingUserInfo.mail_address,
+        role_list: changePendingUserInfo.role_list,
+      });
+      fetchUserList();
+      toast({
+        title: "ユーザ情報が正常に更新されました。",
+        status: "success",
+        duration: 5000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: "ユーザ情報の更新に失敗しました。",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
   };
   return (
-    <Card mb={{ base: "0px", lg: "20px" }} alignItems="center" p="30px">
-      <Flex minHeight="15vh">
+    <Card
+      mb={{ base: "0px", lg: "20px" }}
+      alignItems="center"
+      p={{ base: "15px", md: "30px" }}
+    >
+      <Flex minHeight={{ base: "10vh", md: "15vh" }}>
         <Flex
           alignItems="center"
+          justifyContent="center"
           width="100%"
-          maxWidth="800px"
+          maxWidth={{ base: "100%", md: "800px" }}
           gap={12}
           mb="20px"
+          ml={{ base: "20px", md: "0px" }}
+          flexDirection="row"
         >
           <Avatar
-            size={"xl"}
+            size={{ base: "lg", md: "xl" }}
             src={targetUserInfo?.avatar_img_path}
             border="2px"
             onClick={() =>
@@ -95,10 +119,14 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
             }
           />
           <Flex flexDirection="column" alignItems="flex-start" flex={1}>
-            <Text fontWeight="bold" fontSize="2xl" mb="10px">
+            <Text
+              fontWeight="bold"
+              fontSize={{ base: "xl", md: "2xl" }}
+              mb="10px"
+            >
               {targetUserInfo?.user_name}
             </Text>
-            <Text fontSize="md" fontWeight="400">
+            <Text fontSize={{ base: "sm", md: "md" }} fontWeight="400">
               メールアドレス: {targetUserInfo?.mail_address}
             </Text>
           </Flex>
@@ -107,11 +135,15 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
       <Divider
         borderColor="rgba(79, 209, 197, 1)"
         borderWidth="3px"
-        mb="30px"
+        mb={{ base: "10px", md: "30px" }}
       />
-      <Flex flexDirection="column" gap={5}>
-        <Flex alignItems="center" gap={10}>
-          <Text fontWeight="bold" fontSize="xl" width="80px">
+      <Flex flexDirection="column" gap={{ base: 2, md: 5 }}>
+        <Flex alignItems="center" gap={{ base: 5, md: 10 }}>
+          <Text
+            fontWeight="bold"
+            fontSize={{ base: "sm", md: "xl" }}
+            width="80px"
+          >
             学年:
           </Text>
           {isEditing ? (
@@ -134,13 +166,17 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
               ))}
             </Select>
           ) : (
-            <Text fontSize="xl" fontWeight="400">
+            <Text fontSize={{ base: "sm", md: "xl" }} fontWeight="400">
               {targetUserInfo?.grade}
             </Text>
           )}
         </Flex>
-        <Flex alignItems="center" gap={10}>
-          <Text fontWeight="bold" fontSize="xl" width="80px">
+        <Flex alignItems="center" gap={{ base: 5, md: 10 }}>
+          <Text
+            fontWeight="bold"
+            fontSize={{ base: "sm", md: "xl" }}
+            width="80px"
+          >
             役割:
           </Text>
           <Flex flexWrap="wrap" gap={2}>
@@ -154,7 +190,7 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
                 : targetUserInfo?.role_list
               )?.map((role, index) => <RoleBadge key={index} text={role} />)
             ) : (
-              <Text fontSize="xl" fontWeight="400">
+              <Text fontSize={{ base: "sm", md: "xl" }} fontWeight="400">
                 担当はありません
               </Text>
             )}
@@ -166,15 +202,15 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
             borderWidth="2px"
             borderColor="gray.200"
             overflowY="auto"
-            height="20vh"
+            height={{ base: "15vh", md: "20vh" }}
             maxWidth="300px"
             mx="auto"
           >
-            <Table variant="unstyled" size="sm">
+            <Table variant="unstyled" size={{ base: "xs", md: "sm" }}>
               <Tbody>
                 {roleList.map((role, index) => (
                   <Tr key={role} onClick={() => handleRoleChange(role)}>
-                    <Td width="30px" px={2}>
+                    <Td width="30px" height={{ base: "10px" }} px={2}>
                       {checkRole(role) && (
                         <Icon
                           as={FaCheck}
@@ -195,12 +231,19 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
         )}
       </Flex>
       {isEditing ? (
-        <Flex position="absolute" bottom="2" right="2" gap={4} m={6}>
+        <Flex
+          position="absolute"
+          bottom="2"
+          right="2"
+          gap={4}
+          m={{ base: 3, md: 6 }}
+        >
           <Button
             w={buttonWidth}
             colorScheme="gray"
             variant="solid"
-            size="lg"
+            size={{ base: "xs", md: "lg" }}
+            fontSize={{ base: "xs", md: "md" }}
             onClick={() => {
               setChangePendingUserInfo({
                 ...targetUserInfo,
@@ -215,7 +258,8 @@ export const SettingInfo: React.FC<SettingInfoProps> = ({
             w={buttonWidth}
             colorScheme="teal"
             variant="solid"
-            size="lg"
+            size={{ base: "xs", md: "lg" }}
+            fontSize={{ base: "xs", md: "md" }}
             onClick={() => {
               setIsEditing(false);
               submitUserInfo();

--- a/frontend/src/features/UserList/index.tsx
+++ b/frontend/src/features/UserList/index.tsx
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import { GetUsersInfo200ResponseInner } from "../../schema";
+import { sortUsersByGrade } from "../../models/grade/grade";
 
 interface UserListProps {
   userInfo: GetUsersInfo200ResponseInner[];
@@ -31,17 +32,17 @@ export const UserList: React.FC<UserListProps> = ({
     setTargetUserId(userId);
   };
   const [isShowObUser, setIsShowObUser] = useState(false);
+  const sortedUserInfo = sortUsersByGrade(userInfo);
   const filteredUserInfo = useMemo(() => {
     return isShowObUser
-      ? userInfo
-      : userInfo.filter((user) => user.grade !== "OB");
-  }, [userInfo, isShowObUser]);
+      ? sortedUserInfo
+      : sortedUserInfo.filter((user) => user.grade !== "OB");
+  }, [sortedUserInfo, isShowObUser]);
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const checked = e.target.checked;
     console.log("Checkbox checked:", checked);
     setIsShowObUser(checked);
   };
-
   return (
     <Card mb={{ base: "0px", lg: "20px" }} alignItems="center">
       <Box
@@ -59,7 +60,7 @@ export const UserList: React.FC<UserListProps> = ({
             width="100%"
             mb="10px"
           >
-            <Text fontSize="2xl" fontWeight="bold">
+            <Text fontSize={{ base: "xl", md: "2xl" }} fontWeight="bold">
               ユーザ一覧
             </Text>
             <Flex alignItems="center" gap={3}>
@@ -77,7 +78,7 @@ export const UserList: React.FC<UserListProps> = ({
             borderWidth="3px"
             mb="10px"
           />
-          <Box overflowY="auto" height="65vh">
+          <Box overflowY="auto" height={{ base: "25vh", md: "65vh" }}>
             <Table variant="simple" size={{ base: "sm", md: "md" }}>
               <Thead>
                 <Tr>

--- a/frontend/src/models/grade/grade.ts
+++ b/frontend/src/models/grade/grade.ts
@@ -1,0 +1,16 @@
+import { GetUsersInfo200ResponseInner } from "../../schema";
+
+export const gradeOrder = ["Teacher", "D3", "D2", "D1", "M2", "M1", "U4"];
+export const sortUsersByGrade = (
+  users: GetUsersInfo200ResponseInner[]
+): GetUsersInfo200ResponseInner[] => {
+  return users.sort((a, b) => {
+    if (a.grade === "OB" && b.grade !== "OB") return 1;
+    if (a.grade !== "OB" && b.grade === "OB") return -1;
+
+    if (a.grade === b.grade) {
+      return a.user_id - b.user_id;
+    }
+    return gradeOrder.indexOf(a.grade) - gradeOrder.indexOf(b.grade);
+  });
+};

--- a/frontend/src/models/role/role.ts
+++ b/frontend/src/models/role/role.ts
@@ -3,8 +3,8 @@ import { AuthUser } from "../../userContext";
 export const CHIEF = "チーフ";
 export const INFRA = "インフラ";
 export const isChief = (authUser?: AuthUser) => {
-  return authUser && (authUser.role_list.includes(CHIEF) ?? []);
+  return authUser && (authUser.role_list?.includes(CHIEF) ?? []);
 };
 export const isInfra = (authUser?: AuthUser) => {
-  return authUser && (authUser.role_list.includes(INFRA) ?? []);
+  return authUser && (authUser.role_list?.includes(INFRA) ?? []);
 };

--- a/frontend/src/routes/UserSetting/index.tsx
+++ b/frontend/src/routes/UserSetting/index.tsx
@@ -37,7 +37,7 @@ export const UserSetting = () => {
           lg: "0.6fr 1fr",
         }}
         templateRows={{
-          base: "repeat(2, 1fr)",
+          base: "0.6fr 1.35fr",
           lg: "1fr",
         }}
         gap={{ base: "20px", xl: "20px" }}


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

- #196 
- #197 

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- ユーザ情報を更新した際Toastで通知をする
- 在学生を上部に表示し、学年順に整列させる
- モバイル用に一部対応できていない箇所があるので修正

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->
- 登録処理が完了したときにToastが表示できることを確認しました
<img width="898" alt="スクリーンショット 2024-10-13 13 00 19" src="https://github.com/user-attachments/assets/563bb97d-91e9-4da3-9363-dd302565545c">

- ユーザ一覧でOBが在校生よりも下部に表示されることを確認しました
<img width="1459" alt="スクリーンショット 2024-10-13 12 10 40" src="https://github.com/user-attachments/assets/fbc07c38-b6d0-42e2-804d-cb3f544aa6d9">


- モバイルデザイン
<img width="309" alt="スクリーンショット 2024-10-13 12 56 52" src="https://github.com/user-attachments/assets/48626a6b-9969-4d43-8b2d-89ea25b262c8">
