### PR TITLE
WebAuthnのRegisterボタンを削除してプルダウンに移動する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Home from "./routes/Home";
 import AccessHistory from "./routes/AccessHistory";
 import Profile from "./routes/Profile";
 import SignInWebauthn from "./routes/SignInWebauthn";
+import RegisterWebauthn from "./routes/RegisterWebauthn";
 import SignInDigest from "./routes/SignInDigest";
 import SignUp from "./routes/SignUp";
 import LabAssistant from "./routes/LabAssistant";
@@ -63,6 +64,7 @@ const App = () => {
                 <Route path="/profile" element={<Profile />} />
                 <Route path="/ranking" element={<Ranking />} />
                 <Route path="/sign-in-webauthn" element={<SignInWebauthn />} />
+                <Route path="/register-webauthn" element={<RegisterWebauthn />} />
                 <Route path="/lab-assistant" element={<LabAssistant />} />
                 <Route path="/sign-in-digest" element={<SignInDigest />} />
                 <Route path="/user-setting" element={<UserSetting />} />

--- a/frontend/src/features/MobileNav/index.tsx
+++ b/frontend/src/features/MobileNav/index.tsx
@@ -35,6 +35,10 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
   const faviconPath =
     "https://drive.google.com/thumbnail?id=1xud5OvptQUPXmaVxuk1CZ8hWXa780_jq&sz=w1000";
 
+
+  const handleRegisterWebAuthn = () => {
+    navigate("/register-webauthn");
+  };
   const handleSignOut = () => {
     setAuthUser(undefined);
     navigate("/sign-in-webauthn");
@@ -124,6 +128,7 @@ const MobileNav = ({ onOpen, ...rest }: MobileProps) => {
                 >
                   Profile
                 </MenuItem>
+                <MenuItem onClick={handleRegisterWebAuthn}>Register biometric metrics</MenuItem>
                 <MenuItem>Change Password</MenuItem>
                 <MenuDivider />
                 <MenuItem onClick={handleSignOut}>Sign out</MenuItem>


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

- #201 

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- プルダウンに生体認証登録を追加する
- SignInページからregisterボタンを削除する

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->

- login後にプルダウンで生体認証登録ボタン
![image](https://github.com/user-attachments/assets/ef96c0da-5da3-47aa-9e90-605a96dbe2f8)

- Register
![image](https://github.com/user-attachments/assets/1883cb50-c237-48dd-832f-70a739e5f921)

- Sign In
![image](https://github.com/user-attachments/assets/5841eb95-1b35-4204-8cb3-8e6624ecf440)

