### PR TITLE
Publish Releaseを押すとデプロイされるようにGitHubActionsを組む

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,18 +8,18 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Deploy to rental server
-      uses: appleboy/ssh-action@master
-      with:
-        host: ${{ secrets.SERVER_HOST }}
-        username: ${{ secrets.SERVER_USER }}
-        key: ${{ secrets.SERVER_SSH_KEY }}
-        port: ${{ secrets.SERVER_PORT }}
-        script_stop: true
-        script: |
-          cd ISDL_Sentinel
-          git pull origin main
-          make build-up prod
+      - name: Checkout code
+        uses: actions/checkout@v2
+  
+      - name: Deploy to rental server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          port: ${{ secrets.SERVER_PORT }}
+          script_stop: true
+          script: |
+            cd ISDL_Sentinel
+            git pull origin main
+            make build-up prod


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

- #212

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- publish releaseをクリックするとお名前.comのサーバにデプロイするCIを組む

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->

検証はまだしていません．

## デプロイ方針
1. 初回デプロイはscpでローカルからデプロイ先のサーバにファイルをコピー（git pullはignoreされたファイルが取得できないため）
2. make build-up prodでアプリケーションを起動
3. githubのリリース機能でv1.0.0をリリース
4. 変更がある場合はv1.0.1をリリース（publish release）すると自動的にyamlのスクリプトを実行してデプロイ完了
