### PR TITLE
chage passwordスキーマの変更に応じてchange password apiを修正

### DIFF
--- a/backend/internal/controllers/change_password_controller.go
+++ b/backend/internal/controllers/change_password_controller.go
@@ -2,7 +2,7 @@ package controllers
 
 import (
     "net/http"
-	"strconv"
+    "strconv"
 
     "github.com/gin-gonic/gin"
     "github.com/ISDL-dev/ISDL-Sentinel/backend/internal/services"
@@ -11,14 +11,14 @@ import (
 
 func PutChangePasswordController(ctx *gin.Context){
     
-	userIDStr := ctx.Param("id")
+    userIDStr := ctx.Param("user_id")
     userID, err := strconv.Atoi(userIDStr)
     if err != nil {
         ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
         return
     }
-	
-	var user schema.PutChangePasswordRequest
+    
+    var user schema.PutChangePasswordRequest
     if err := ctx.ShouldBind(&user); err != nil {
         ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
         return

--- a/backend/internal/controllers/change_password_controller.go
+++ b/backend/internal/controllers/change_password_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
     "net/http"
+	"strconv"
 
     "github.com/gin-gonic/gin"
     "github.com/ISDL-dev/ISDL-Sentinel/backend/internal/services"
@@ -9,14 +10,21 @@ import (
 )
 
 func PutChangePasswordController(ctx *gin.Context){
-    var user schema.PutChangePasswordRequest
-
+    
+	userIDStr := ctx.Param("id")
+    userID, err := strconv.Atoi(userIDStr)
+    if err != nil {
+        ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
+        return
+    }
+	
+	var user schema.PutChangePasswordRequest
     if err := ctx.ShouldBind(&user); err != nil {
         ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
         return
     }
 
-    if err := services.PutChangePasswordService(user); err != nil {
+    if err := services.PutChangePasswordService(user, userID); err != nil {
         ctx.JSON(http.StatusConflict, gin.H{"error": err.Error()})
         return
     }

--- a/backend/internal/repositories/change_password_repository.go
+++ b/backend/internal/repositories/change_password_repository.go
@@ -31,13 +31,13 @@ func ChangePasswordRepository(user schema.PutChangePasswordRequest, userID int) 
         return fmt.Errorf("failed to get user credential: %w", err)
     }
 
-    if !(id == userID && password == user.BeforePassword) {
+    if !(userId == userID && password == user.BeforePassword) {
         return fmt.Errorf("worng username or password")
     }
 
     UpdateUserPasswordQuery := `update user set password = ? where id = ?;`
 
-    _ , err = infrastructures.DB.Exec(UpdateUserPasswordQuery, user.AfterPassword, id)
+    _ , err = infrastructures.DB.Exec(UpdateUserPasswordQuery, user.AfterPassword, userId)
     if err != nil {
         return fmt.Errorf("failed to change password: %w", err)
     }

--- a/backend/internal/repositories/change_password_repository.go
+++ b/backend/internal/repositories/change_password_repository.go
@@ -16,11 +16,11 @@ func ChangePasswordRepository(user schema.PutChangePasswordRequest, userID int) 
 
     row := infrastructures.DB.QueryRow(getUserCredentialQuery, userID)
     
-    var id int
+    var userId int
     var password string
     
     err := row.Scan(
-        &id,
+        &userId,
         &password,
     )
 

--- a/backend/internal/routers.go
+++ b/backend/internal/routers.go
@@ -34,7 +34,7 @@ func SetRoutes(router *gin.Engine) {
 		v1.GET("/role", controllers.GetRoleController)
 		v1.GET("/grade", controllers.GetGradeController)
 		v1.POST("/sign-up", controllers.PostSignUpController)
-		v1.PUT("/change-password/:id", controllers.PutChangePasswordController)
+		v1.PUT("/change-password/:user_id", controllers.PutChangePasswordController)
 
 		oauthn := v1.Group("/oauthn")
 		{

--- a/backend/internal/routers.go
+++ b/backend/internal/routers.go
@@ -34,7 +34,7 @@ func SetRoutes(router *gin.Engine) {
 		v1.GET("/role", controllers.GetRoleController)
 		v1.GET("/grade", controllers.GetGradeController)
 		v1.POST("/sign-up", controllers.PostSignUpController)
-		v1.PUT("/change-password", controllers.PutChangePasswordController)
+		v1.PUT("/change-password/:id", controllers.PutChangePasswordController)
 
 		oauthn := v1.Group("/oauthn")
 		{

--- a/backend/internal/services/change_password_service.go
+++ b/backend/internal/services/change_password_service.go
@@ -5,6 +5,6 @@ import (
     "github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
 )
 
-func PutChangePasswordService(user schema.PutChangePasswordRequest) error {
-    return repositories.ChangePasswordRepository(user)
+func PutChangePasswordService(user schema.PutChangePasswordRequest, userID int) error {
+    return repositories.ChangePasswordRepository(user, userID)
 }


### PR DESCRIPTION
## 関連 Issue

## 変更内容（やること）

- chage passwordスキーマの変更（auth_user_nameの削除）に応じてauth_user_nameの代わりにパスパラメータのidを利用

## 動作確認の方法・結果
 - パスワードの変更、ログイン成功
<img width="834" alt="スクリーンショット 0006-10-22 15 06 37" src="https://github.com/user-attachments/assets/dbecf609-3857-4477-a4cf-5eb6f8324694">
<img width="1505" alt="スクリーンショット 0006-10-22 15 06 46" src="https://github.com/user-attachments/assets/34aa22c8-2452-499e-8286-aa5cb5c82ddc">
<img width="1510" alt="スクリーンショット 0006-10-22 15 06 56" src="https://github.com/user-attachments/assets/c7cb6627-0c53-4edd-96cb-3da071a4d996">

 - 変更前パスワードでログイン失敗
<img width="1509" alt="スクリーンショット 0006-10-22 15 07 13" src="https://github.com/user-attachments/assets/6b56beca-52c5-411e-8619-e4bc76de28f7">

