### PR TITLE
リバースプロキシを追加する

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -7,7 +7,7 @@ MYSQL_USER="light"
 MYSQL_PASSWORD="light"
 TZ="Asia/Tokyo"
 
-BACKEND_ENDPOINT="http://localhost:3000/v1"
+BACKEND_ENDPOINT="http://localhost/v1"
 GOOGLE_CREDENTIALS_PATH="/go/src/app/internal/infrastructures/credentials"
 GOOGLE_DRIVE_FOLDER_ID="1M6RhjFK9O2dk3bp6Ipo0-WSyiQI5_27J"
 WEBHOOKURL="https://prod-22.japaneast.logic.azure.com:443/workflows/baaff47922d44cf1b94d32c1392f965f/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=k7eFfJ8C0-3XLKbmGW6_mi31GGTHE2iXTktmNqmySyo"

--- a/.env.prod
+++ b/.env.prod
@@ -7,7 +7,7 @@ MYSQL_USER="light"
 MYSQL_PASSWORD="light"
 TZ="Asia/Tokyo"
 
-BACKEND_ENDPOINT="http://160.251.121.161:3000/v1"
+BACKEND_ENDPOINT="http://160.251.121.161/v1"
 GOOGLE_CREDENTIALS_PATH="/go/src/app/internal/infrastructures/credentials"
 GOOGLE_DRIVE_FOLDER_ID="1M6RhjFK9O2dk3bp6Ipo0-WSyiQI5_27J"
 WEBHOOKURL="https://prod-22.japaneast.logic.azure.com:443/workflows/baaff47922d44cf1b94d32c1392f965f/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=k7eFfJ8C0-3XLKbmGW6_mi31GGTHE2iXTktmNqmySyo"

--- a/backend/internal/controllers/digest_auth_login_controller.go
+++ b/backend/internal/controllers/digest_auth_login_controller.go
@@ -2,12 +2,12 @@ package controllers
 
 import (
 	"fmt"
-    "net/http"
 	"log"
+	"net/http"
 
-    "github.com/gin-gonic/gin"
-    "github.com/ISDL-dev/ISDL-Sentinel/backend/internal/services"
-    "github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/schema"
+	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/services"
+	"github.com/gin-gonic/gin"
 )
 
 func DigestLoginController(ctx *gin.Context) {
@@ -21,7 +21,7 @@ func DigestLoginController(ctx *gin.Context) {
 
 		nonce := services.GenerateNonce()
 		wwwAuthenticateHeader := services.CreateWWWAuthenticateHeader(nonce)
-		ctx.Header("WWW-Authenticate", wwwAuthenticateHeader)
+		ctx.Header("X-WWW-Authenticate", wwwAuthenticateHeader)
 		ctx.JSON(http.StatusUnauthorized, schema.Error{
 			Code:    http.StatusUnauthorized,
 			Message: "Authentication required",

--- a/backend/internal/routers.go
+++ b/backend/internal/routers.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"os"
+
 	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/controllers"
 	"github.com/ISDL-dev/ISDL-Sentinel/backend/internal/infrastructures"
 	"github.com/gin-contrib/cors"
@@ -9,7 +11,7 @@ import (
 
 func SetRoutes(router *gin.Engine) {
 	router.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"*"},
+		AllowOrigins:     []string{"http://" + os.Getenv("SERVER_NAME")},
 		AllowOriginFunc:  func(origin string) bool { return true },
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "PATCH"},
 		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},

--- a/backend/internal/services/webauthn_registration_service.go
+++ b/backend/internal/services/webauthn_registration_service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 
 	model "github.com/ISDL-dev/ISDL-Sentinel/backend/internal/models"
@@ -21,8 +22,8 @@ var (
 func GetBeginRegistrationService(userName string, w http.ResponseWriter, r *http.Request) (*protocol.CredentialCreation, error) {
 	Wc, err = webauthn.New(&webauthn.Config{
 		RPDisplayName: "ISDL-Sentinel",
-		RPID:          "localhost",
-		RPOrigin:      "http://localhost:4000",
+		RPID:          os.Getenv("SERVER_NAME"),
+		RPOrigin:      "http://" + os.Getenv("SERVER_NAME"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create WebAuthn from config: %w", err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3'
+
 services: 
   frontend:
     container_name: isdl-sentinel-frontend
@@ -17,6 +18,8 @@ services:
       - ./frontend:/app
     ports:
       - 4000:4000
+    networks:
+      - isdl-sentinel
     
   backend:
     container_name: isdl-sentinel-backend
@@ -36,6 +39,8 @@ services:
       - ./backend:/go/src/app
     ports:
       - 3000:3000
+    networks:
+      - isdl-sentinel
 
   database:
     image: mysql:8.0
@@ -55,6 +60,23 @@ services:
         - ./database/sqls_${ENV_TYPE:-dev}:/docker-entrypoint-initdb.d
     ports:
         - 3306:3306
+    networks:
+      - isdl-sentinel
+  
+  nginx:
+    image: nginx:latest
+    container_name: isdl-sentinel-nginx
+    ports:
+      - 80:80
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+    networks:
+      - isdl-sentinel
+
+networks:
+  isdl-sentinel:
+    name: isdl-sentinel
+
 volumes:
   mysql_data:
     name: isdl_sentinel_data_${ENV_TYPE:-dev}

--- a/frontend/src/routes/SignInDigest/index.tsx
+++ b/frontend/src/routes/SignInDigest/index.tsx
@@ -83,7 +83,7 @@ export default function SignInDigest() {
         headers: { 'Authorization': '' },
       });
 
-      const wwwAuthenticate = challengeResponse.headers['www-authenticate'];
+      const wwwAuthenticate = challengeResponse.headers['x-www-authenticate'];
       if (!wwwAuthenticate) {
         throw new Error('WWW-Authenticate header is missing');
       }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,47 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    # Define upstream for backend
+    upstream backend {
+        server isdl-sentinel-backend:3000;
+    }
+
+    # Define upstream for frontend
+    upstream frontend {
+        server isdl-sentinel-frontend:4000;
+    }
+
+    server {
+        listen 80;
+
+        # Proxy requests to /v1 to the backend
+        location /v1/ {
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Proxy all other requests to the frontend
+        location / {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

- #240 

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- リバースプロキシを追加してアクセスを80portだけにする．
- コンテナ内はコンテナ間通信をするようにする．（サーバのipを叩かずにコンテナ名で通信する）

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->

- [http://160.251.121.161/](http://160.251.121.161/)でアクセス可能なことを確認
- frontendとbackendが通信可能なことを確認

## 改善点
- WebAuthnのAPIがhttps通信 or localhostのみ使用可能なため，prod環境では使用できない．したがって，https化する必要性がある
- Digest認証でログインしようとするとポップアップでloginが求められる．これはheaderで`www-authenticate`を追加しているためである．そのため，この名前を変更する必要性がある．
