### PR TITLE
SSL証明書をデコード

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Decode and place the SSL certificate
-        run: |
-          echo "${{ secrets.SSL_CERT_PEM_BASE64 }}" | base64 -d > ./proxy/ssl/www.isdl-sentinel.com.pem
-          echo "${{ secrets.SSL_CERT_NOPASS_KEY_BASE64 }}" | base64 -d > ./proxy/ssl/www.isdl-sentinel.com.key
   
       - name: Deploy to rental server
         uses: appleboy/ssh-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Decode and place the SSL certificate
+        run: |
+          echo "${{ secrets.SSL_CERT_PEM_BASE64 }}" | base64 -d > ./proxy/ssl/www.isdl-sentinel.com.pem
+          echo "${{ secrets.SSL_CERT_NOPASS_KEY_BASE64 }}" | base64 -d > ./proxy/ssl/www.isdl-sentinel.com.key
   
       - name: Deploy to rental server
         uses: appleboy/ssh-action@master
@@ -21,6 +26,8 @@ jobs:
           script_stop: true
           script: |
             cd ISDL-Sentinel
+            echo "${{ secrets.SSL_CERT_PEM_BASE64 }}" | base64 -d > ./proxy/ssl/www.isdl-sentinel.com.pem
+            echo "${{ secrets.SSL_CERT_NOPASS_KEY_BASE64 }}" | base64 -d > ./proxy/ssl/www.isdl-sentinel.com.nopass.key
             git pull origin main
             make down prod
             make build-up prod


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

-

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- 発行済みSSL証明書（.pem）と秘密鍵（.key）をgithub secretsにbase64でエンコードしたものを保存しproxy/ssl直下にデコードするように追加

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->

-
