### PR TITLE
GHAリモートサーバからレンタルサーバにSSL証明書を転送

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Decode the SSL certificate
+        run: |
+          mkdir -p ~/ISDL-Sentinel/proxy/ssl
+          echo "${{ secrets.SSL_CERT_PEM_BASE64 }}" | base64 -d > ~/ISDL-Sentinel/proxy/ssl/www.isdl-sentinel.com.pem
+          echo "${{ secrets.SSL_CERT_NOPASS_KEY_BASE64 }}" | base64 -d > ~/ISDL-Sentinel/proxy/ssl/www.isdl-sentinel.com.nopass.key
+
+      - name: Copy SSL files to the server
+        run: |
+          scp ~/ISDL-Sentinel/proxy/ssl/www.isdl-sentinel.com.pem ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:~/ISDL-Sentinel/proxy/ssl/
+          scp ~/ISDL-Sentinel/proxy/ssl/www.isdl-sentinel.com.nopass.key ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:~/ISDL-Sentinel/proxy/ssl/
   
       - name: Deploy to rental server
         uses: appleboy/ssh-action@master
@@ -20,9 +31,7 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           script_stop: true
           script: |
-            cd ISDL-Sentinel
-            echo "${{ secrets.SSL_CERT_PEM_BASE64 }}" | base64 -d > ./proxy/ssl/www.isdl-sentinel.com.pem
-            echo "${{ secrets.SSL_CERT_NOPASS_KEY_BASE64 }}" | base64 -d > ./proxy/ssl/www.isdl-sentinel.com.nopass.key
+            cd ~/ISDL-Sentinel
             git pull origin main
             make down prod
             make build-up prod


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

-

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- base64でデコードしたファイルはGHAのリモートサーバに保存
- その後scpでレンタルサーバに転送処理を追加

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->

-
