### PR TITLE
ランキングのユーザアイコンにAvaterを使用し他の画面と統一する

### DIFF
--- a/frontend/src/features/RankingList/index.tsx
+++ b/frontend/src/features/RankingList/index.tsx
@@ -1,10 +1,10 @@
 import {
+  Avatar,
   Card,
   CardBody,
   Grid,
   GridItem,
   Heading,
-  Image,
   Table,
   TableContainer,
   Tbody,
@@ -110,14 +110,13 @@ export const RankingList: React.FC<RankingListProps> = ({
               alignItems="center"
             >
               <Top3Icon rank={item.rank - 1}></Top3Icon>
-              <Image
-                src={item.avatar_img_path}
-                alt={`${item.avatar_id}`}
-                boxSize={{
-                  base: "48px",
-                  md: "64px",
+              <Avatar
+                size={{
+                  base: "md",
+                  md: "lg",
                 }}
-                cursor="pointer"
+                src={item.avatar_img_path}
+                border="2px"
                 onClick={() =>
                   navigate("/profile", {
                     state: { userId: item.user_id },
@@ -174,19 +173,16 @@ export const RankingList: React.FC<RankingListProps> = ({
                                 justifySelf="start"
                                 marginRight={{ base: 0, md: 8 }}
                               >
-                                <Image
-                                  src={item.avatar_img_path}
-                                  alt={`${item.avatar_id}`}
-                                  boxSize={{
-                                    base: "36px",
-                                    md: "50px",
+                                <Avatar
+                                  size={{
+                                    base: "sm",
+                                    md: "md",
                                   }}
-                                  cursor="pointer"
+                                  src={item.avatar_img_path}
+                                  border="2px"
                                   onClick={() =>
                                     navigate("/profile", {
-                                      state: {
-                                        userId: item.user_id,
-                                      },
+                                      state: { userId: item.user_id },
                                     })
                                   }
                                 />


### PR DESCRIPTION
## 関連 Issue

<!-- #xxで指定 -->

- #268 

## 変更内容（やること）

<!-- 変更内容、実現すること -->

- ランキングのアイコンにChakraのAvaterを使用

## 動作確認の方法・結果

<!-- frontendの実装があるときは作った画面も載せる -->

- アイコンが正しく表示できることを確認しました

<img width="1458" alt="スクリーンショット 2025-02-21 0 57 14" src="https://github.com/user-attachments/assets/ee0c95cf-2d67-41ad-8b84-3830fe05326c" />

**モバイル表示**

<img width="310" alt="image" src="https://github.com/user-attachments/assets/21e61797-5b0e-46b5-af7a-e264f7157b95" />
